### PR TITLE
UX restyle: nestmux-aligned theme + labeled sidebar with anchored popovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ stress-cpu.js
 # Local seed/check helpers (contain service_role key, never commit)
 _seed-*.mjs
 _check-*.mjs
+
+# Dev-only UI preview screenshots
+.preview-shots/
+.preview-shots-before/

--- a/e2e/helpers/harness.ts
+++ b/e2e/helpers/harness.ts
@@ -22,7 +22,7 @@ function uniqueTmp(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
 }
 
-export async function launchHarness(opts?: { withRepo?: boolean }): Promise<Harness> {
+export async function launchHarness(opts?: { withRepo?: boolean; env?: Record<string, string> }): Promise<Harness> {
   const homeDir = uniqueTmp('raven-e2e-home-')
   let repoDir = ''
   if (opts?.withRepo !== false) {
@@ -44,6 +44,7 @@ export async function launchHarness(opts?: { withRepo?: boolean }): Promise<Harn
   env.RAVEN_HOME = homeDir
   env.HOME = homeDir
   env.USERPROFILE = homeDir
+  if (opts?.env) Object.assign(env, opts.env)
 
   const app = await electron.launch({
     args: [MAIN_JS, `--user-data-dir=${userDataDir}`],

--- a/e2e/zz-screenshots.spec.ts
+++ b/e2e/zz-screenshots.spec.ts
@@ -21,14 +21,9 @@ test('capture restyled UI', async () => {
 
   const shot = (name: string) => page.screenshot({ path: join(OUT, name) })
 
-  // 1. Initial view (worktrees panel open by default)
+  // 1. Initial view — Worktrees is an inline accordion, open by default
   await shot('01-initial.png')
-
-  // close the default side panel for a clean baseline
-  if (await page.locator('.side-panel').count()) {
-    await page.locator('.nav-item[title="Worktrees"]').first().click()
-    await page.waitForTimeout(300)
-  }
+  await shot('04-worktrees-accordion.png')
 
   // 2. The "Choose AI" picker (multi-AI identity, branded tiles)
   await page.keyboard.press('Control+t')
@@ -37,20 +32,27 @@ test('capture restyled UI', async () => {
   await page.keyboard.press('Escape') // close dialog before interacting with nav
   await page.waitForTimeout(300)
 
-  // 3. Side panels docked to the right
-  const panels: Array<[string, string]> = [
-    ['Worktrees', '04-worktrees.png'],
+  // 3. Nav popovers — anchored to the right of the nav item (NOT a docked panel)
+  const popovers: Array<[string, string]> = [
     ['Snippets', '05-snippets.png'],
     ['MCP', '06-mcp.png'],
     ['Workspaces', '07-workspaces.png'],
+    ['Command History', '14-cmdhist.png'],
   ]
-  for (const [title, file] of panels) {
+  for (const [title, file] of popovers) {
     await page.locator(`.nav-item[title="${title}"]`).first().click()
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(450)
     await shot(file)
-    await page.locator(`.nav-item[title="${title}"]`).first().click() // toggle closed
+    await page.keyboard.press('Escape') // close popover before the next one
     await page.waitForTimeout(200)
   }
+
+  // 4. Worktrees accordion collapsed, then re-open for a clean baseline
+  await page.locator('.nav-item[title="Worktrees"]').first().click()
+  await page.waitForTimeout(300)
+  await shot('04b-worktrees-collapsed.png')
+  await page.locator('.nav-item[title="Worktrees"]').first().click()
+  await page.waitForTimeout(300)
 
   // 4. Teams — now populated via the e2e fixtures (lands on Activity feed)
   await page.locator('.nav-item[title="Team"]').first().click()

--- a/e2e/zz-screenshots.spec.ts
+++ b/e2e/zz-screenshots.spec.ts
@@ -34,6 +34,7 @@ test('capture restyled UI', async () => {
 
   // 3. Nav popovers — anchored to the right of the nav item (NOT a docked panel)
   const popovers: Array<[string, string]> = [
+    ['Session', '15-session.png'],
     ['Snippets', '05-snippets.png'],
     ['MCP', '06-mcp.png'],
     ['Workspaces', '07-workspaces.png'],

--- a/e2e/zz-screenshots.spec.ts
+++ b/e2e/zz-screenshots.spec.ts
@@ -1,0 +1,100 @@
+import { test } from '@playwright/test'
+import { launchHarness, teardown } from './helpers/harness'
+import { mkdirSync } from 'fs'
+import { join, resolve } from 'path'
+
+// Preview-only spec. NOT part of CI. Generates UI screenshots for design review.
+// Output is written to .preview-shots/ (gitignored). Run: npx playwright test zz-screenshots
+
+const OUT = resolve(__dirname, '..', '.preview-shots')
+
+const RUN = process.env.PREVIEW_SHOTS === '1'
+
+test('capture restyled UI', async () => {
+  test.skip(!RUN, 'preview-only: set PREVIEW_SHOTS=1 to generate screenshots')
+  mkdirSync(OUT, { recursive: true })
+  const h = await launchHarness({ withRepo: true })
+  const { page } = h
+
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.waitForTimeout(800)
+
+  const shot = (name: string) => page.screenshot({ path: join(OUT, name) })
+
+  // 1. Initial view (worktrees panel open by default)
+  await shot('01-initial.png')
+
+  // close the default side panel for a clean baseline
+  if (await page.locator('.side-panel').count()) {
+    await page.locator('.nav-item[title="Worktrees"]').first().click()
+    await page.waitForTimeout(300)
+  }
+
+  // 2. The "Choose AI" picker (multi-AI identity, branded tiles)
+  await page.keyboard.press('Control+t')
+  await page.waitForTimeout(600)
+  await shot('02-choose-ai.png')
+  await page.keyboard.press('Escape') // close dialog before interacting with nav
+  await page.waitForTimeout(300)
+
+  // 3. Side panels docked to the right
+  const panels: Array<[string, string]> = [
+    ['Worktrees', '04-worktrees.png'],
+    ['Snippets', '05-snippets.png'],
+    ['MCP', '06-mcp.png'],
+    ['Workspaces', '07-workspaces.png'],
+  ]
+  for (const [title, file] of panels) {
+    await page.locator(`.nav-item[title="${title}"]`).first().click()
+    await page.waitForTimeout(500)
+    await shot(file)
+    await page.locator(`.nav-item[title="${title}"]`).first().click() // toggle closed
+    await page.waitForTimeout(200)
+  }
+
+  // 4. Teams — now populated via the e2e fixtures (lands on Activity feed)
+  await page.locator('.nav-item[title="Team"]').first().click()
+  await page.waitForTimeout(1000)
+  await shot('08-teams-activity.png')
+
+  // Teams sub-views via the left nav inside Teams
+  const teamViews: Array<[string, string]> = [
+    ['Chat', '10-teams-chat.png'],
+    ['Repos', '11-teams-repos.png'],
+    ['Members', '12-teams-members.png'],
+    ['Snippets', '13-teams-snippets.png'],
+  ]
+  for (const [label, file] of teamViews) {
+    const btn = page.locator('.teams-workspace-nav button', { hasText: label }).first()
+    if (await btn.count()) {
+      await btn.click()
+      await page.waitForTimeout(600)
+      await shot(file)
+    }
+  }
+
+  // back to terminal
+  const back = page.locator('text=Back').first()
+  if (await back.count()) { await back.click(); await page.waitForTimeout(400) }
+
+  // 5. Spotlight (Ctrl+K)
+  await page.keyboard.press('Control+k')
+  await page.waitForTimeout(500)
+  await shot('09-spotlight.png')
+  await page.keyboard.press('Escape')
+
+  await teardown(h)
+})
+
+test('capture Teams welcome/join (no team)', async () => {
+  test.skip(!RUN, 'preview-only: set PREVIEW_SHOTS=1 to generate screenshots')
+  mkdirSync(OUT, { recursive: true })
+  const h = await launchHarness({ withRepo: true, env: { RAVEN_PREVIEW_EMPTY: '1' } })
+  const { page } = h
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await page.waitForTimeout(800)
+  await page.locator('.nav-item[title="Team"]').first().click()
+  await page.waitForTimeout(1000)
+  await page.screenshot({ path: join(OUT, '03-teams-welcome.png') })
+  await teardown(h)
+})

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -87,6 +87,8 @@ contextBridge.exposeInMainWorld('platform', {
 
 contextBridge.exposeInMainWorld('appFlags', {
   e2eBypass: process.env.RAVEN_E2E === '1',
+  // Dev-only: render Teams in its "no team yet" welcome/join state during preview.
+  previewEmptyTeams: process.env.RAVEN_PREVIEW_EMPTY === '1',
 })
 
 contextBridge.exposeInMainWorld('windowControls', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource-variable/geist-mono": "^5.2.8",
+        "@fontsource-variable/inter": "^5.2.8",
         "@paddle/paddle-js": "^1.6.2",
         "@supabase/supabase-js": "^2.101.1",
         "@xterm/addon-fit": "^0.10.0",
@@ -1313,6 +1315,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.8.tgz",
+      "integrity": "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@gar/promisify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nest",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nest",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -19,6 +19,7 @@
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0",
         "electron-updater": "^6.8.3",
+        "lucide-react": "^1.17.0",
         "node-pty": "^1.1.0",
         "pidtree": "^0.6.0",
         "pidusage": "^4.0.1",
@@ -5966,6 +5967,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource-variable/geist-mono": "^5.2.8",
+    "@fontsource-variable/inter": "^5.2.8",
     "@paddle/paddle-js": "^1.6.2",
     "@supabase/supabase-js": "^2.101.1",
     "@xterm/addon-fit": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
     "electron-updater": "^6.8.3",
+    "lucide-react": "^1.17.0",
     "node-pty": "^1.1.0",
     "pidtree": "^0.6.0",
     "pidusage": "^4.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { PortsBanner } from './components/PortsBanner'
 import ConfirmDialog from './components/ConfirmDialog'
 import ConversationSidebar from './components/ConversationSidebar'
 import NavSidebar from './components/NavSidebar'
-import SidePanel from './components/SidePanel'
 import LayoutPicker from './components/LayoutPicker'
 import { Radio, Mic } from 'lucide-react'
 import { NewWorktreeModal } from './components/NewWorktreeModal'
@@ -40,7 +39,7 @@ import SharedTerminalViewer from './components/SharedTerminalViewer'
 import { terminalShareService } from './lib/terminalShareService'
 import ResourceBar from './components/ResourceBar'
 import StatusBar from './components/StatusBar'
-import type { MetricsPaneInput, PanelId } from './types'
+import type { MetricsPaneInput } from './types'
 
 
 let paneCounter = 0
@@ -104,7 +103,6 @@ export default function App() {
   const [convSidebarOpen, setConvSidebarOpen] = useState(false)
   const [globalSearchOpen, setGlobalSearchOpen] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
-  const [activePanel, setActivePanel] = useState<PanelId | null>('worktrees')
   const [fontSize, setFontSize] = useState<number>(() => {
     const saved = localStorage.getItem('nest-font-size')
     return saved ? parseInt(saved, 10) : 13
@@ -927,8 +925,25 @@ export default function App() {
 
       <div className="app-body">
       <NavSidebar
-        activePanel={activePanel}
-        onSelectPanel={(id) => setActivePanel((p) => (p === id ? null : id))}
+        repoPath={activeTab.repoPath}
+        onWorktreeSelect={handleWorktreeSelect}
+        onNewWorktree={handleNewWorktree}
+        worktreeRefreshKey={worktreeRefreshKey}
+        onRepoLink={handleRepoLink}
+        onRepoUnlink={handleRepoUnlink}
+        onSnippetSend={(content) => {
+          const id = focusedPaneIdRef.current
+          if (id) window.pty.write(id, content + '\r')
+        }}
+        onSnippetBroadcast={(content) => {
+          activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
+        }}
+        onWorkspaceSave={saveWorkspace}
+        onWorkspaceLoad={loadWorkspace}
+        onCommandRun={(cmd) => {
+          const id = focusedPaneIdRef.current
+          if (id) window.pty.write(id, cmd + '\r')
+        }}
         onTeamsOpen={() => {
           if (plan !== 'team') { setShowUpgrade(true); return }
           setTeamsOpen(true)
@@ -948,33 +963,6 @@ export default function App() {
         onUpgrade={() => setShowUpgrade(true)}
         activeCellRepoPath={activeCellRepoPath}
       />
-      {activePanel && (
-        <SidePanel
-          panel={activePanel}
-          onClose={() => setActivePanel(null)}
-          repoPath={activeTab.repoPath}
-          activeCellRepoPath={activeCellRepoPath}
-          onWorktreeSelect={handleWorktreeSelect}
-          onNewWorktree={handleNewWorktree}
-          worktreeRefreshKey={worktreeRefreshKey}
-          onRepoLink={handleRepoLink}
-          onRepoUnlink={handleRepoUnlink}
-          onSnippetSend={(content) => {
-            const id = focusedPaneIdRef.current
-            if (id) window.pty.write(id, content + '\r')
-          }}
-          onSnippetBroadcast={(content) => {
-            activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
-          }}
-          onUpgrade={() => setShowUpgrade(true)}
-          onWorkspaceSave={saveWorkspace}
-          onWorkspaceLoad={loadWorkspace}
-          onCommandRun={(cmd) => {
-            const id = focusedPaneIdRef.current
-            if (id) window.pty.write(id, cmd + '\r')
-          }}
-        />
-      )}
       <div className="workspace">
         {isInitialState ? (
           <EmptyState onNewPane={() => setAddingToCell(0)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { PortsBanner } from './components/PortsBanner'
 import ConfirmDialog from './components/ConfirmDialog'
 import ConversationSidebar from './components/ConversationSidebar'
 import NavSidebar from './components/NavSidebar'
+import SidePanel from './components/SidePanel'
 import LayoutPicker from './components/LayoutPicker'
 import { Radio, Mic } from 'lucide-react'
 import { NewWorktreeModal } from './components/NewWorktreeModal'
@@ -946,26 +947,34 @@ export default function App() {
         profileLoading={profileLoading}
         onUpgrade={() => setShowUpgrade(true)}
         activeCellRepoPath={activeCellRepoPath}
-        repoPath={activeTab.repoPath}
-        onWorktreeSelect={handleWorktreeSelect}
-        onNewWorktree={handleNewWorktree}
-        worktreeRefreshKey={worktreeRefreshKey}
-        onRepoLink={handleRepoLink}
-        onRepoUnlink={handleRepoUnlink}
-        onSnippetSend={(content) => {
-          const id = focusedPaneIdRef.current
-          if (id) window.pty.write(id, content + '\r')
-        }}
-        onSnippetBroadcast={(content) => {
-          activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
-        }}
-        onWorkspaceSave={saveWorkspace}
-        onWorkspaceLoad={loadWorkspace}
-        onCommandRun={(cmd) => {
-          const id = focusedPaneIdRef.current
-          if (id) window.pty.write(id, cmd + '\r')
-        }}
       />
+      {activePanel && (
+        <SidePanel
+          panel={activePanel}
+          onClose={() => setActivePanel(null)}
+          repoPath={activeTab.repoPath}
+          activeCellRepoPath={activeCellRepoPath}
+          onWorktreeSelect={handleWorktreeSelect}
+          onNewWorktree={handleNewWorktree}
+          worktreeRefreshKey={worktreeRefreshKey}
+          onRepoLink={handleRepoLink}
+          onRepoUnlink={handleRepoUnlink}
+          onSnippetSend={(content) => {
+            const id = focusedPaneIdRef.current
+            if (id) window.pty.write(id, content + '\r')
+          }}
+          onSnippetBroadcast={(content) => {
+            activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
+          }}
+          onUpgrade={() => setShowUpgrade(true)}
+          onWorkspaceSave={saveWorkspace}
+          onWorkspaceLoad={loadWorkspace}
+          onCommandRun={(cmd) => {
+            const id = focusedPaneIdRef.current
+            if (id) window.pty.write(id, cmd + '\r')
+          }}
+        />
+      )}
       <div className="workspace">
         {isInitialState ? (
           <EmptyState onNewPane={() => setAddingToCell(0)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,10 @@ import TabBar from './components/TabBar'
 import { PortsBanner } from './components/PortsBanner'
 import ConfirmDialog from './components/ConfirmDialog'
 import ConversationSidebar from './components/ConversationSidebar'
-import Sidebar from './components/Sidebar'
+import ActivityBar from './components/ActivityBar'
+import SidePanel from './components/SidePanel'
+import LayoutPicker from './components/LayoutPicker'
+import { Radio, Mic } from 'lucide-react'
 import { NewWorktreeModal } from './components/NewWorktreeModal'
 import { QuickWorktreePalette } from './components/QuickWorktreePalette'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
@@ -102,7 +105,6 @@ export default function App() {
   const [globalSearchOpen, setGlobalSearchOpen] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
   const [activePanel, setActivePanel] = useState<PanelId | null>('worktrees')
-  const sidebarExpanded = activePanel !== null
   const [fontSize, setFontSize] = useState<number>(() => {
     const saved = localStorage.getItem('nest-font-size')
     return saved ? parseInt(saved, 10) : 13
@@ -868,7 +870,27 @@ export default function App() {
         onTabColorChange={handleTabColorChange}
         isWin={window.platform?.isWin ?? false}
         tabActivity={tabActivity}
-        rightSlot={<ResourceBar panes={activePanesPayload} />}
+        rightSlot={
+          <div className="tabbar-tools">
+            <LayoutPicker current={layout} onChange={applyLayout} />
+            <button
+              className={`tabbar-tool${broadcastMode ? ' active' : ''}`}
+              onClick={() => setBroadcastMode((v) => !v)}
+              title={broadcastMode ? 'Broadcast ON — click to turn off' : 'Broadcast'}
+            >
+              <Radio size={17} />
+            </button>
+            <button
+              className="tabbar-tool"
+              onClick={(isTranscribing || isModelLoading) ? undefined : toggleListening}
+              title={isListening ? 'Stop voice (F5)' : isTranscribing ? 'Processing…' : isModelLoading ? 'Loading model…' : 'Voice (F5)'}
+              style={isListening ? { color: 'var(--accent)' } : undefined}
+            >
+              <Mic size={17} />
+            </button>
+            <ResourceBar panes={activePanesPayload} />
+          </div>
+        }
       />
       <PortsBanner
         rootRepoPath={activeTab.repoPath ?? null}
@@ -904,56 +926,55 @@ export default function App() {
       )}
 
       <div className="app-body">
-      <Sidebar
-        expanded={sidebarExpanded}
-        onToggle={() => setActivePanel((p) => (p ? null : 'worktrees'))}
-        broadcastMode={broadcastMode}
-        onBroadcastToggle={() => setBroadcastMode((v) => !v)}
-        layout={layout}
-        onLayoutChange={applyLayout}
-        onNewPane={addNextPane}
-        onHistoryOpen={() => setConvSidebarOpen(true)}
-        onSnippetSend={(content) => {
-          const id = focusedPaneIdRef.current
-          if (id) window.pty.write(id, content + '\r')
-        }}
-        onSnippetBroadcast={(content) => {
-          activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
-        }}
-        onCommandRun={(cmd) => {
-          const id = focusedPaneIdRef.current
-          if (id) window.pty.write(id, cmd + '\r')
-        }}
-        onWorkspaceSave={saveWorkspace}
-        onWorkspaceLoad={loadWorkspace}
-        isWin={window.platform?.isWin ?? false}
-        isTrialActive={isTrialActive}
-        trialDaysLeft={trialDaysLeft}
-        profileLoading={profileLoading}
-        onUpgrade={() => setShowUpgrade(true)}
+      <ActivityBar
+        activePanel={activePanel}
+        onSelectPanel={(id) => setActivePanel((p) => (p === id ? null : id))}
         onTeamsOpen={() => {
           if (plan !== 'team') { setShowUpgrade(true); return }
           setTeamsOpen(true)
         }}
-        pendingInvitesCount={pendingInvitesCount}
         onMyReposOpen={() => {
           if (plan !== 'pro' && plan !== 'team') { setShowUpgrade(true); return }
           setMyReposOpen(true)
         }}
-        plan={plan}
-        repoPath={activeTab.repoPath}
-        onRepoLink={handleRepoLink}
-        onRepoUnlink={handleRepoUnlink}
-        isListening={isListening}
-        isTranscribing={isTranscribing}
-        isModelLoading={isModelLoading}
-        onMicToggle={toggleListening}
+        onHistoryOpen={() => setConvSidebarOpen(true)}
+        onNewPane={addNextPane}
         onJoinTerminal={() => setShowJoinViewer(true)}
+        pendingInvitesCount={pendingInvitesCount}
+        plan={plan}
+        isTrialActive={isTrialActive}
+        trialDaysLeft={trialDaysLeft}
+        profileLoading={profileLoading}
+        onUpgrade={() => setShowUpgrade(true)}
         activeCellRepoPath={activeCellRepoPath}
-        onWorktreeSelect={handleWorktreeSelect}
-        onNewWorktree={handleNewWorktree}
-        worktreeRefreshKey={worktreeRefreshKey}
       />
+      {activePanel && (
+        <SidePanel
+          panel={activePanel}
+          onClose={() => setActivePanel(null)}
+          repoPath={activeTab.repoPath}
+          activeCellRepoPath={activeCellRepoPath}
+          onWorktreeSelect={handleWorktreeSelect}
+          onNewWorktree={handleNewWorktree}
+          worktreeRefreshKey={worktreeRefreshKey}
+          onRepoLink={handleRepoLink}
+          onRepoUnlink={handleRepoUnlink}
+          onSnippetSend={(content) => {
+            const id = focusedPaneIdRef.current
+            if (id) window.pty.write(id, content + '\r')
+          }}
+          onSnippetBroadcast={(content) => {
+            activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
+          }}
+          onUpgrade={() => setShowUpgrade(true)}
+          onWorkspaceSave={saveWorkspace}
+          onWorkspaceLoad={loadWorkspace}
+          onCommandRun={(cmd) => {
+            const id = focusedPaneIdRef.current
+            if (id) window.pty.write(id, cmd + '\r')
+          }}
+        />
+      )}
       <div className="workspace">
         {isInitialState ? (
           <EmptyState onNewPane={() => setAddingToCell(0)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ import SharedTerminalViewer from './components/SharedTerminalViewer'
 import { terminalShareService } from './lib/terminalShareService'
 import ResourceBar from './components/ResourceBar'
 import StatusBar from './components/StatusBar'
-import type { MetricsPaneInput } from './types'
+import type { MetricsPaneInput, PanelId } from './types'
 
 
 let paneCounter = 0
@@ -101,7 +101,8 @@ export default function App() {
   const [convSidebarOpen, setConvSidebarOpen] = useState(false)
   const [globalSearchOpen, setGlobalSearchOpen] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
-  const [sidebarExpanded, setSidebarExpanded] = useState(false)
+  const [activePanel, setActivePanel] = useState<PanelId | null>('worktrees')
+  const sidebarExpanded = activePanel !== null
   const [fontSize, setFontSize] = useState<number>(() => {
     const saved = localStorage.getItem('nest-font-size')
     return saved ? parseInt(saved, 10) : 13
@@ -905,7 +906,7 @@ export default function App() {
       <div className="app-body">
       <Sidebar
         expanded={sidebarExpanded}
-        onToggle={() => setSidebarExpanded((v) => !v)}
+        onToggle={() => setActivePanel((p) => (p ? null : 'worktrees'))}
         broadcastMode={broadcastMode}
         onBroadcastToggle={() => setBroadcastMode((v) => !v)}
         layout={layout}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,7 @@ import TabBar from './components/TabBar'
 import { PortsBanner } from './components/PortsBanner'
 import ConfirmDialog from './components/ConfirmDialog'
 import ConversationSidebar from './components/ConversationSidebar'
-import ActivityBar from './components/ActivityBar'
-import SidePanel from './components/SidePanel'
+import NavSidebar from './components/NavSidebar'
 import LayoutPicker from './components/LayoutPicker'
 import { Radio, Mic } from 'lucide-react'
 import { NewWorktreeModal } from './components/NewWorktreeModal'
@@ -926,7 +925,7 @@ export default function App() {
       )}
 
       <div className="app-body">
-      <ActivityBar
+      <NavSidebar
         activePanel={activePanel}
         onSelectPanel={(id) => setActivePanel((p) => (p === id ? null : id))}
         onTeamsOpen={() => {
@@ -947,34 +946,26 @@ export default function App() {
         profileLoading={profileLoading}
         onUpgrade={() => setShowUpgrade(true)}
         activeCellRepoPath={activeCellRepoPath}
+        repoPath={activeTab.repoPath}
+        onWorktreeSelect={handleWorktreeSelect}
+        onNewWorktree={handleNewWorktree}
+        worktreeRefreshKey={worktreeRefreshKey}
+        onRepoLink={handleRepoLink}
+        onRepoUnlink={handleRepoUnlink}
+        onSnippetSend={(content) => {
+          const id = focusedPaneIdRef.current
+          if (id) window.pty.write(id, content + '\r')
+        }}
+        onSnippetBroadcast={(content) => {
+          activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
+        }}
+        onWorkspaceSave={saveWorkspace}
+        onWorkspaceLoad={loadWorkspace}
+        onCommandRun={(cmd) => {
+          const id = focusedPaneIdRef.current
+          if (id) window.pty.write(id, cmd + '\r')
+        }}
       />
-      {activePanel && (
-        <SidePanel
-          panel={activePanel}
-          onClose={() => setActivePanel(null)}
-          repoPath={activeTab.repoPath}
-          activeCellRepoPath={activeCellRepoPath}
-          onWorktreeSelect={handleWorktreeSelect}
-          onNewWorktree={handleNewWorktree}
-          worktreeRefreshKey={worktreeRefreshKey}
-          onRepoLink={handleRepoLink}
-          onRepoUnlink={handleRepoUnlink}
-          onSnippetSend={(content) => {
-            const id = focusedPaneIdRef.current
-            if (id) window.pty.write(id, content + '\r')
-          }}
-          onSnippetBroadcast={(content) => {
-            activePaneIds.forEach((id) => window.pty.write(id, content + '\r'))
-          }}
-          onUpgrade={() => setShowUpgrade(true)}
-          onWorkspaceSave={saveWorkspace}
-          onWorkspaceLoad={loadWorkspace}
-          onCommandRun={(cmd) => {
-            const id = focusedPaneIdRef.current
-            if (id) window.pty.write(id, cmd + '\r')
-          }}
-        />
-      )}
       <div className="workspace">
         {isInitialState ? (
           <EmptyState onNewPane={() => setAddingToCell(0)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { useUserPreferences } from './hooks/useUserPreferences'
 import SharedTerminalViewer from './components/SharedTerminalViewer'
 import { terminalShareService } from './lib/terminalShareService'
 import ResourceBar from './components/ResourceBar'
+import StatusBar from './components/StatusBar'
 import type { MetricsPaneInput } from './types'
 
 
@@ -1079,6 +1080,12 @@ export default function App() {
         )}
       </div>
       </div>
+
+      <StatusBar
+        paneCount={cells.filter(Boolean).length}
+        workspaceName={activeTab.name}
+        repoName={activeTab.repoPath ? activeTab.repoPath.split(/[\\/]/).filter(Boolean).pop() : undefined}
+      />
 
       <ConversationSidebar open={convSidebarOpen} onClose={() => setConvSidebarOpen(false)} />
 

--- a/src/components/ActivityBar.tsx
+++ b/src/components/ActivityBar.tsx
@@ -1,0 +1,280 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  GitBranch,
+  Users,
+  FolderGit2,
+  SquareCode,
+  Plug,
+  Ellipsis,
+  Plus,
+  Settings,
+  History,
+  Terminal,
+  Layers,
+} from 'lucide-react'
+import SettingsPanel from './SettingsPanel'
+import UserMenu from './UserMenu'
+import { supabase } from '../lib/supabase'
+import type { PanelId } from '../types'
+
+interface Props {
+  activePanel: PanelId | null
+  onSelectPanel: (id: PanelId) => void
+  onTeamsOpen: () => void
+  onMyReposOpen: () => void
+  onHistoryOpen: () => void
+  onNewPane: () => void
+  onJoinTerminal: () => void
+  pendingInvitesCount: number
+  plan: 'free' | 'pro' | 'team' | null
+  isTrialActive: boolean
+  trialDaysLeft: number
+  profileLoading: boolean
+  onUpgrade: () => void
+  activeCellRepoPath?: string
+}
+
+export default function ActivityBar({
+  activePanel,
+  onSelectPanel,
+  onTeamsOpen,
+  onMyReposOpen,
+  onHistoryOpen,
+  onNewPane,
+  onJoinTerminal,
+  pendingInvitesCount,
+  plan,
+  isTrialActive,
+  trialDaysLeft,
+  profileLoading,
+  onUpgrade,
+  activeCellRepoPath,
+}: Props) {
+  // ── Update state (ported from Sidebar) ──────────────────────────────────
+  const [updateState, setUpdateState] = useState<
+    'idle' | 'checking' | 'up-to-date' | 'update-found' | 'error'
+  >('idle')
+  const [userEmail, setUserEmail] = useState('')
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUserEmail(data.user?.email ?? '')
+    })
+  }, [])
+
+  async function handleCheckUpdates() {
+    if (updateState === 'checking') return
+    setUpdateState('checking')
+    const result = await window.updater.checkForUpdates()
+    if (result === 'up-to-date') {
+      setUpdateState('up-to-date')
+      setTimeout(() => setUpdateState('idle'), 3000)
+    } else if (result === 'update-found') {
+      setUpdateState('update-found')
+      setTimeout(() => setUpdateState('idle'), 4000)
+    } else {
+      setUpdateState('error')
+      setTimeout(() => setUpdateState('idle'), 3000)
+    }
+  }
+
+  // ── "More" popover ───────────────────────────────────────────────────────
+  const [moreOpen, setMoreOpen] = useState(false)
+  const moreMenuRef = useRef<HTMLDivElement>(null)
+  const moreBtnRef = useRef<HTMLButtonElement>(null)
+  const [morePos, setMorePos] = useState<{ top: number; left: number } | null>(null)
+
+  // Position the More menu to the right of the button
+  useEffect(() => {
+    if (!moreOpen || !moreBtnRef.current) return
+    const rect = moreBtnRef.current.getBoundingClientRect()
+    setMorePos({ top: rect.top, left: rect.right + 6 })
+  }, [moreOpen])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!moreOpen) return
+    const handler = (e: MouseEvent) => {
+      if (
+        moreBtnRef.current?.contains(e.target as Node) ||
+        moreMenuRef.current?.contains(e.target as Node)
+      )
+        return
+      setMoreOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMoreOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', handler)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [moreOpen])
+
+  const badgeLabel = pendingInvitesCount > 9 ? '9+' : String(pendingInvitesCount)
+  const moreActive = activePanel === 'workspaces' || activePanel === 'cmdhist'
+
+  function pickMore(id: PanelId) {
+    onSelectPanel(id)
+    setMoreOpen(false)
+  }
+
+  return (
+    <div className="activity-bar">
+      {/* ── Top group ───────────────────────────────────────────────────── */}
+
+      {/* Worktrees */}
+      <button
+        className={`activity-btn${activePanel === 'worktrees' ? ' active' : ''}`}
+        onClick={() => onSelectPanel('worktrees')}
+        title="Worktrees"
+        aria-label="Worktrees"
+      >
+        <GitBranch />
+        {activePanel === 'worktrees' && <span className="activity-btn-indicator" />}
+      </button>
+
+      {/* Team */}
+      <button
+        className="activity-btn"
+        onClick={onTeamsOpen}
+        title={
+          pendingInvitesCount > 0
+            ? `Team — ${pendingInvitesCount} pending invite${pendingInvitesCount === 1 ? '' : 's'}`
+            : 'Team'
+        }
+        aria-label="Team"
+      >
+        <Users />
+        {pendingInvitesCount > 0 && (
+          <span className="activity-badge" aria-label={`${pendingInvitesCount} pending invites`}>
+            {badgeLabel}
+          </span>
+        )}
+      </button>
+
+      {/* My Repos */}
+      <button
+        className="activity-btn"
+        onClick={onMyReposOpen}
+        title="My Repos"
+        aria-label="My Repos"
+      >
+        <FolderGit2 />
+      </button>
+
+      {/* Snippets */}
+      <button
+        className={`activity-btn${activePanel === 'snippets' ? ' active' : ''}`}
+        onClick={() => onSelectPanel('snippets')}
+        title="Snippets"
+        aria-label="Snippets"
+      >
+        <SquareCode />
+      </button>
+
+      {/* MCP */}
+      <button
+        className={`activity-btn${activePanel === 'mcp' ? ' active' : ''}`}
+        onClick={() => onSelectPanel('mcp')}
+        title="MCP"
+        aria-label="MCP"
+      >
+        <Plug />
+      </button>
+
+      {/* More */}
+      <button
+        ref={moreBtnRef}
+        className={`activity-btn${moreActive ? ' active' : ''}`}
+        onClick={() => setMoreOpen(v => !v)}
+        title="More"
+        aria-label="More"
+        aria-expanded={moreOpen}
+      >
+        <Ellipsis />
+      </button>
+
+      {/* More popover — rendered inline to avoid portal complexity */}
+      {moreOpen && morePos && (
+        <div
+          ref={moreMenuRef}
+          className="activity-more-menu"
+          style={{ top: morePos.top, left: morePos.left }}
+        >
+          <button
+            className="activity-more-item"
+            onClick={() => pickMore('workspaces')}
+          >
+            <Layers />
+            Workspaces
+          </button>
+          <button
+            className="activity-more-item"
+            onClick={() => pickMore('cmdhist')}
+          >
+            <Terminal />
+            Command History
+          </button>
+          <button
+            className="activity-more-item"
+            onClick={() => { onHistoryOpen(); setMoreOpen(false) }}
+          >
+            <History />
+            History
+          </button>
+          <button
+            className="activity-more-item"
+            onClick={() => { onJoinTerminal(); setMoreOpen(false) }}
+          >
+            <Terminal />
+            Join Terminal
+          </button>
+        </div>
+      )}
+
+      {/* ── Spacer ──────────────────────────────────────────────────────── */}
+      <div className="activity-spacer" />
+
+      {/* ── Bottom group ────────────────────────────────────────────────── */}
+
+      {/* New terminal */}
+      <button
+        className="activity-btn"
+        onClick={onNewPane}
+        title="New terminal (Ctrl+T)"
+        aria-label="New terminal"
+      >
+        <Plus />
+      </button>
+
+      {/* Settings — SettingsPanel renders its own trigger button internally.
+          We wrap it in an activity-btn-sized slot and suppress its default
+          titlebar-btn trigger by rendering SettingsPanel which owns the
+          open/close state via its internal button. */}
+      <div className="activity-btn" style={{ position: 'relative', cursor: 'pointer' }}>
+        <Settings style={{ width: 22, height: 22, color: '#868686', pointerEvents: 'none' }} />
+        {/* SettingsPanel renders a transparent trigger <button> on top */}
+        <SettingsPanel
+          updateState={updateState}
+          onCheckUpdates={handleCheckUpdates}
+          userEmail={userEmail}
+          activeRepoPath={activeCellRepoPath}
+        />
+      </div>
+
+      {/* User avatar (account menu) */}
+      {!profileLoading && (
+        <UserMenu
+          plan={plan}
+          isTrialActive={isTrialActive}
+          trialDaysLeft={trialDaysLeft}
+          onUpgrade={onUpgrade}
+          expanded={false}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -111,7 +111,7 @@ export default function ActivityFeed({ repos, githubToken, teamMembers: _teamMem
   const [error, setError] = useState<string | null>(null)
   const { connectGitHub } = useGitHub()
 
-  // Estabilizar la dependencia del useEffect — evita re-fetch si el array cambia de referencia pero no de contenido
+  // Stabilize the useEffect dependency — avoids re-fetch when the array changes reference but not content
   const repoNames = useMemo(() => repos.map(r => r.repo_full_name).join(','), [repos])
 
   useEffect(() => {

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useGitHub } from '../hooks/useGitHub'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_FEED } from '../lib/e2eFixtures'
 
 interface GitHubEvent {
   id: string
@@ -164,6 +166,29 @@ export default function ActivityFeed({ repos, githubToken, teamMembers: _teamMem
     load()
     return () => { alive = false }
   }, [repoNames, githubToken])
+
+  if (isE2EPreview()) {
+    return (
+      <div className="feed-container">
+        {FX_FEED.map(ev => (
+          <div key={ev.id} className="feed-event">
+            <div className="feed-avatar" aria-hidden />
+            <div className="feed-event-content">
+              <div className="feed-event-top">
+                <div className="feed-event-main"><span className="feed-actor">{ev.actor}</span> {ev.action}</div>
+                <span className="feed-time">{ev.ago}</span>
+              </div>
+              {ev.detail && <div className="feed-event-detail">"{ev.detail}"</div>}
+              <div className="feed-event-meta">
+                <span className={`feed-type-badge ${ev.badge}`}>{ev.badge === 'pr' ? 'PR' : ev.badge}</span>
+                <span className="feed-repo">{ev.repo}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
 
   // No token
   if (!githubToken) {

--- a/src/components/BrowserCell.tsx
+++ b/src/components/BrowserCell.tsx
@@ -400,7 +400,7 @@ export default function BrowserCell({ pane, cellId, onClose, borderColor, siblin
                 onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
               >
                 <span style={{ color: 'rgba(255, 255, 255, 0.7)', fontSize: 13, fontWeight: 400 }}>localhost</span>
-                <span style={{ fontFamily: "'JetBrains Mono', ui-monospace, monospace", color: '#0066FF', fontWeight: 600, fontSize: 13, letterSpacing: '0.02em' }}>:{port}</span>
+                <span style={{ fontFamily: 'var(--font-mono)', color: '#0066FF', fontWeight: 600, fontSize: 13, letterSpacing: '0.02em' }}>:{port}</span>
               </button>
             ))}
           </div>

--- a/src/components/CommandHistoryPanel.tsx
+++ b/src/components/CommandHistoryPanel.tsx
@@ -74,7 +74,7 @@ export default function CommandHistoryPanel({ onRun }: Props) {
                 <span
                   className="snippet-name"
                   title={cmd}
-                  style={{ fontFamily: 'monospace', fontSize: 11, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                  style={{ fontFamily: 'var(--font-mono)', fontSize: 11, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
                 >
                   {cmd}
                 </span>

--- a/src/components/CommandHistoryPanel.tsx
+++ b/src/components/CommandHistoryPanel.tsx
@@ -4,9 +4,10 @@ import { useFixedPopover } from '../hooks/useFixedPopover'
 
 interface Props {
   onRun?: (cmd: string) => void
+  docked?: boolean
 }
 
-export default function CommandHistoryPanel({ onRun }: Props) {
+export default function CommandHistoryPanel({ onRun, docked }: Props) {
   const [open, setOpen] = useState(false)
   const [history, setHistory] = useState(getHistory)
   const [search, setSearch] = useState('')
@@ -17,7 +18,7 @@ export default function CommandHistoryPanel({ onRun }: Props) {
   useEffect(() => subscribe(() => setHistory(getHistory())), [])
 
   useEffect(() => {
-    if (!open) return
+    if (!open || docked) return
     const handler = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setOpen(false)
@@ -25,7 +26,7 @@ export default function CommandHistoryPanel({ onRun }: Props) {
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [open])
+  }, [open, docked])
 
   const filtered = search.trim()
     ? history.filter((cmd) => cmd.toLowerCase().includes(search.toLowerCase()))
@@ -33,7 +34,53 @@ export default function CommandHistoryPanel({ onRun }: Props) {
 
   const handleRun = (cmd: string) => {
     onRun?.(cmd)
-    setOpen(false)
+    if (!docked) setOpen(false)
+  }
+
+  const body = (
+    <>
+      <div className="snippet-panel-header">
+        <span style={{ fontSize: 12, fontWeight: 600 }}>Command History</span>
+      </div>
+      <div style={{ padding: '6px 8px' }}>
+        <input
+          className="snippet-input"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ width: '100%', boxSizing: 'border-box' }}
+        />
+      </div>
+      {filtered.length === 0 && (
+        <p className="snippet-empty">{history.length === 0 ? 'No commands yet.' : 'No match.'}</p>
+      )}
+      <div className="snippet-list" style={{ maxHeight: 300, overflowY: 'auto' }}>
+        {filtered.map((cmd, i) => (
+          <div key={i} className="snippet-item">
+            <span
+              className="snippet-name"
+              title={cmd}
+              style={{ fontFamily: 'var(--font-mono)', fontSize: 11, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {cmd}
+            </span>
+            <button
+              className="snippet-send-btn"
+              onClick={() => handleRun(cmd)}
+              title="Run in active pane"
+            >
+              Run
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+
+  if (docked) {
+    return (
+      <div className="snippet-panel cmd-history-panel--docked">{body}</div>
+    )
   }
 
   return (
@@ -52,42 +99,7 @@ export default function CommandHistoryPanel({ onRun }: Props) {
 
       {open && popPos && (
         <div ref={popoverRef} className="snippet-panel" style={{ position: 'fixed', top: popPos.top, left: popPos.left, right: 'auto' }}>
-          <div className="snippet-panel-header">
-            <span style={{ fontSize: 12, fontWeight: 600 }}>Command History</span>
-          </div>
-          <div style={{ padding: '6px 8px' }}>
-            <input
-              className="snippet-input"
-              placeholder="Search…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              autoFocus
-              style={{ width: '100%', boxSizing: 'border-box' }}
-            />
-          </div>
-          {filtered.length === 0 && (
-            <p className="snippet-empty">{history.length === 0 ? 'No commands yet.' : 'No match.'}</p>
-          )}
-          <div className="snippet-list" style={{ maxHeight: 300, overflowY: 'auto' }}>
-            {filtered.map((cmd, i) => (
-              <div key={i} className="snippet-item">
-                <span
-                  className="snippet-name"
-                  title={cmd}
-                  style={{ fontFamily: 'var(--font-mono)', fontSize: 11, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                >
-                  {cmd}
-                </span>
-                <button
-                  className="snippet-send-btn"
-                  onClick={() => handleRun(cmd)}
-                  title="Run in active pane"
-                >
-                  Run
-                </button>
-              </div>
-            ))}
-          </div>
+          {body}
         </div>
       )}
     </div>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -47,11 +47,11 @@ function score(item: PaletteItem, query: string): number {
 }
 
 const SECTION_LABELS: Record<PaletteItem['section'], string> = {
-  actions: 'Acciones',
+  actions: 'Actions',
   tabs: 'Tabs',
   workspaces: 'Workspaces',
   snippets: 'Snippets',
-  history: 'Historial',
+  history: 'History',
 }
 
 export default function CommandPalette({
@@ -117,8 +117,8 @@ export default function CommandPalette({
       items.push({
         id: `tab-${tab.id}`, section: 'tabs',
         label: tab.name,
-        sublabel: `${paneCount} terminal${paneCount !== 1 ? 'es' : ''}`,
-        keywords: 'tab workspace ir',
+        sublabel: `${paneCount} terminal${paneCount !== 1 ? 's' : ''}`,
+        keywords: 'tab workspace go',
         action: () => { onTabSelect(tab.id); onClose() },
       })
     })
@@ -129,7 +129,7 @@ export default function CommandPalette({
         id: `ws-${ws.id}`, section: 'workspaces',
         label: ws.name,
         sublabel: `${ws.layout.rows}×${ws.layout.cols}`,
-        keywords: 'workspace cargar layout',
+        keywords: 'workspace load layout',
         action: () => { onWorkspaceLoad(ws); onClose() },
       })
     })
@@ -140,7 +140,7 @@ export default function CommandPalette({
         id: `sn-${sn.id}`, section: 'snippets',
         label: sn.name,
         sublabel: sn.content.slice(0, 60) + (sn.content.length > 60 ? '…' : ''),
-        keywords: 'snippet enviar comando',
+        keywords: 'snippet send command',
         action: () => {
           if (broadcastMode) onSnippetBroadcast(sn.content)
           else onSnippetSend(sn.content)
@@ -156,7 +156,7 @@ export default function CommandPalette({
         id: `cv-${cv.id}`, section: 'history',
         label: cv.preview.slice(0, 50) || 'No preview',
         sublabel: `${label} · ${cv.accountName} · ${new Date(cv.timestamp).toLocaleDateString()}`,
-        keywords: 'historial conversacion',
+        keywords: 'history conversation',
         action: () => { onHistoryOpen(); onClose() },
       })
     })

--- a/src/components/DailyStandup.tsx
+++ b/src/components/DailyStandup.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import { safeWriteText } from '../lib/clipboard'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_MEMBERS } from '../lib/e2eFixtures'
 
 interface GitHubEvent {
   id: string
@@ -263,6 +265,32 @@ export default function DailyStandup({ repos, githubToken, teamMembers }: DailyS
         setTimeout(() => setCopied(false), 2000)
       }
     })
+  }
+
+  if (isE2EPreview()) {
+    const preview = FX_MEMBERS.slice(0, 2)
+    const previewActivities: Record<string, string[]> = {
+      [preview[0].email]: ['pushed 3 commits to feat/auth-rewrite (platform-api)', 'opened PR #142 "add rate limiter v2" (platform-api)'],
+      [preview[1].email]: ['pushed 2 commits to main (platform-api)'],
+    }
+    return (
+      <div className="standup-container">
+        <div className="standup-header">
+          <span className="standup-title">📋 Standup — {dateLabel}</span>
+        </div>
+        <div className="standup-divider" />
+        {preview.map(member => (
+          <div key={member.email} className="standup-member">
+            <div className="standup-member-name">{member.email}</div>
+            <ul className="standup-member-activity">
+              {previewActivities[member.email].map((act, i) => (
+                <li key={i}>{act}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    )
   }
 
   if (!githubToken) {

--- a/src/components/FileStagingBar.tsx
+++ b/src/components/FileStagingBar.tsx
@@ -44,13 +44,13 @@ export default function FileStagingBar({ files, onRemove, onSend, onCancel }: Pr
         <input
           ref={inputRef}
           className="file-staging-input"
-          placeholder="Mensaje (opcional)…"
+          placeholder="Message (optional)…"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           onKeyDown={handleKeyDown}
         />
         <button className="file-staging-send" onClick={() => { onSend(message); setMessage('') }}>
-          Enviar ↵
+          Send ↵
         </button>
       </div>
     </div>

--- a/src/components/IssueDetail.tsx
+++ b/src/components/IssueDetail.tsx
@@ -266,7 +266,7 @@ export default function IssueDetail({ repoFullName, issue: initialIssue, githubT
           {branchError && <p style={{ color: '#EF4444', fontSize: 11, marginBottom: 6 }}>{branchError}</p>}
           {createdBranchName && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
-              <span style={{ fontSize: 11, color: '#22c55e' }}>✓ Rama creada:</span>
+              <span style={{ fontSize: 11, color: '#22c55e' }}>✓ Branch created:</span>
               <code style={{ fontSize: 11, background: 'var(--bg-secondary)', padding: '2px 6px', borderRadius: 4, color: 'var(--text-primary)' }}>
                 {createdBranchName}
               </code>

--- a/src/components/IssueDetail.tsx
+++ b/src/components/IssueDetail.tsx
@@ -138,7 +138,7 @@ export default function IssueDetail({ repoFullName, issue: initialIssue, githubT
     setCreatingBranch(true)
     setBranchError(null)
     try {
-      // 1. Obtener el default branch del repo
+      // 1. Get the repo's default branch
       const repoRes = await fetch(
         `https://api.github.com/repos/${repoFullName}`,
         { headers: ghHeaders }
@@ -150,7 +150,7 @@ export default function IssueDetail({ repoFullName, issue: initialIssue, githubT
       const repoData = await repoRes.json()
       const defaultBranch: string = repoData.default_branch
 
-      // 2. Obtener el SHA del default branch
+      // 2. Get the SHA of the default branch
       const refRes = await fetch(
         `https://api.github.com/repos/${repoFullName}/git/refs/heads/${defaultBranch}`,
         { headers: ghHeaders }
@@ -162,7 +162,7 @@ export default function IssueDetail({ repoFullName, issue: initialIssue, githubT
       const refData = await refRes.json()
       const sha: string = refData.object.sha
 
-      // 3. Crear el branch
+      // 3. Create the branch
       const slug = toSlug(issue.title)
       const branchName = `issue-${issue.number}-${slug}`
       const createRes = await fetch(

--- a/src/components/MCPPanel.tsx
+++ b/src/components/MCPPanel.tsx
@@ -8,6 +8,7 @@ import ConfirmDialog from './ConfirmDialog'
 interface Props {
   repoPath?: string
   onRequireUpgrade?: () => void
+  docked?: boolean
 }
 
 interface FormState {
@@ -40,7 +41,7 @@ function formToServer(form: FormState): Record<string, unknown> {
   return result
 }
 
-export default function MCPPanel({ repoPath, onRequireUpgrade }: Props) {
+export default function MCPPanel({ repoPath, onRequireUpgrade, docked }: Props) {
   const [open, setOpen] = useState(false)
   const [globalPath, setGlobalPath] = useState('')
   const [globalServers, setGlobalServers] = useState<Record<string, unknown>>({})
@@ -70,15 +71,15 @@ export default function MCPPanel({ repoPath, onRequireUpgrade }: Props) {
   }, [projectPath])
 
   useEffect(() => {
-    if (!open) return
+    if (!open && !docked) return
     window.mcp.globalPath().then((gPath) => {
       setGlobalPath(gPath)
       load(gPath)
     })
-  }, [open, load])
+  }, [open, docked, load])
 
   useEffect(() => {
-    if (!open) return
+    if (!open || docked) return
     const handler = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setOpen(false)
@@ -87,7 +88,7 @@ export default function MCPPanel({ repoPath, onRequireUpgrade }: Props) {
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [open])
+  }, [open, docked])
 
   const expand = (scope: 'global' | 'project', name: string) => {
     const key = `${scope}:${name}`
@@ -343,6 +344,34 @@ export default function MCPPanel({ repoPath, onRequireUpgrade }: Props) {
     )
   }
 
+  const body = (
+    <>
+      {renderSection('global', globalServers)}
+      <div className="mcp-divider" />
+      {renderSection('project', projectServers, !projectPath)}
+    </>
+  )
+
+  const confirmDeleteDialog = confirmDelete ? (
+    <ConfirmDialog
+      title="Remove MCP server"
+      message={`Remove "${confirmDelete.name}"?`}
+      confirmLabel="Remove"
+      confirmDanger
+      onConfirm={() => { remove(confirmDelete.scope, confirmDelete.name); setConfirmDelete(null) }}
+      onCancel={() => setConfirmDelete(null)}
+    />
+  ) : null
+
+  if (docked) {
+    return (
+      <>
+        <div className="mcp-panel mcp-panel--docked">{body}</div>
+        {confirmDeleteDialog}
+      </>
+    )
+  }
+
   return (
     <div className="mcp-wrap" ref={panelRef}>
       <button
@@ -366,22 +395,11 @@ export default function MCPPanel({ repoPath, onRequireUpgrade }: Props) {
 
       {open && popPos && (
         <div ref={popoverRef} className="mcp-panel" style={{ position: 'fixed', top: popPos.top, left: popPos.left, right: 'auto' }}>
-          {renderSection('global', globalServers)}
-          <div className="mcp-divider" />
-          {renderSection('project', projectServers, !projectPath)}
+          {body}
         </div>
       )}
 
-      {confirmDelete && (
-        <ConfirmDialog
-          title="Remove MCP server"
-          message={`Remove "${confirmDelete.name}"?`}
-          confirmLabel="Remove"
-          confirmDanger
-          onConfirm={() => { remove(confirmDelete.scope, confirmDelete.name); setConfirmDelete(null) }}
-          onCancel={() => setConfirmDelete(null)}
-        />
-      )}
+      {confirmDeleteDialog}
     </div>
   )
 }

--- a/src/components/NavPopover.tsx
+++ b/src/components/NavPopover.tsx
@@ -1,0 +1,72 @@
+import { useState, useRef, useEffect, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { useFixedPopover } from '../hooks/useFixedPopover'
+
+interface Props {
+  icon: ReactNode
+  label: string
+  title?: string
+  badge?: ReactNode
+  children: ReactNode
+}
+
+/**
+ * A nav-item trigger that opens an anchored floating popover to the right of
+ * the clicked item (rendered into a portal so the sidebar's overflow can't clip
+ * it). The popover body is only mounted while open. Outside-click and Escape
+ * close the popover — the docked panel bodies inside disable their own close
+ * handlers, so this wrapper owns that behavior.
+ */
+export default function NavPopover({ icon, label, title, badge, children }: Props) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const pos = useFixedPopover(triggerRef, open, popoverRef)
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (popoverRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        className={`nav-item${open ? ' active' : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        title={title ?? label}
+      >
+        {icon}
+        <span className="nav-item-label">{label}</span>
+        {badge}
+      </button>
+
+      {open &&
+        pos &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            className="nav-popover"
+            style={{ position: 'fixed', top: pos.top, left: pos.left }}
+          >
+            {children}
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}

--- a/src/components/NavSidebar.tsx
+++ b/src/components/NavSidebar.tsx
@@ -14,9 +14,8 @@ import {
 } from 'lucide-react'
 import SettingsPanel from './SettingsPanel'
 import UserMenu from './UserMenu'
-import SidePanel from './SidePanel'
 import { supabase } from '../lib/supabase'
-import type { PanelId, Workspace } from '../types'
+import type { PanelId } from '../types'
 
 interface Props {
   // nav / activity-bar props
@@ -34,18 +33,6 @@ interface Props {
   profileLoading: boolean
   onUpgrade: () => void
   activeCellRepoPath?: string
-  // side-panel content props
-  repoPath?: string
-  onWorktreeSelect: (worktreePath: string) => void
-  onNewWorktree: () => void
-  worktreeRefreshKey?: number
-  onRepoLink: () => void
-  onRepoUnlink: () => void
-  onSnippetSend: (content: string) => void
-  onSnippetBroadcast: (content: string) => void
-  onWorkspaceSave: (name: string) => void
-  onWorkspaceLoad: (ws: Workspace) => void
-  onCommandRun: (cmd: string) => void
 }
 
 export default function NavSidebar({
@@ -63,17 +50,6 @@ export default function NavSidebar({
   profileLoading,
   onUpgrade,
   activeCellRepoPath,
-  repoPath,
-  onWorktreeSelect,
-  onNewWorktree,
-  worktreeRefreshKey,
-  onRepoLink,
-  onRepoUnlink,
-  onSnippetSend,
-  onSnippetBroadcast,
-  onWorkspaceSave,
-  onWorkspaceLoad,
-  onCommandRun,
 }: Props) {
   // ── Update state (ported from ActivityBar) ───────────────────────────────
   const [updateState, setUpdateState] = useState<
@@ -213,29 +189,8 @@ export default function NavSidebar({
         </button>
       </div>
 
-      {/* ── Active panel content ─────────────────────────────────────────── */}
-      {activePanel && (
-        <div className="nav-content">
-          <SidePanel
-            embedded
-            panel={activePanel}
-            onClose={() => {}}
-            repoPath={repoPath}
-            activeCellRepoPath={activeCellRepoPath}
-            onWorktreeSelect={onWorktreeSelect}
-            onNewWorktree={onNewWorktree}
-            worktreeRefreshKey={worktreeRefreshKey}
-            onRepoLink={onRepoLink}
-            onRepoUnlink={onRepoUnlink}
-            onSnippetSend={onSnippetSend}
-            onSnippetBroadcast={onSnippetBroadcast}
-            onUpgrade={onUpgrade}
-            onWorkspaceSave={onWorkspaceSave}
-            onWorkspaceLoad={onWorkspaceLoad}
-            onCommandRun={onCommandRun}
-          />
-        </div>
-      )}
+      {/* Spacer pushes the footer to the bottom */}
+      <div className="nav-spacer" />
 
       {/* ── Footer ──────────────────────────────────────────────────────── */}
       <div className="nav-footer">

--- a/src/components/NavSidebar.tsx
+++ b/src/components/NavSidebar.tsx
@@ -14,13 +14,17 @@ import {
 } from 'lucide-react'
 import SettingsPanel from './SettingsPanel'
 import UserMenu from './UserMenu'
+import NavPopover from './NavPopover'
+import SidePanel from './SidePanel'
+import SnippetPanel from './SnippetPanel'
+import MCPPanel from './MCPPanel'
+import WorkspacePanel from './WorkspacePanel'
+import CommandHistoryPanel from './CommandHistoryPanel'
 import { supabase } from '../lib/supabase'
-import type { PanelId } from '../types'
+import type { Workspace } from '../types'
 
 interface Props {
   // nav / activity-bar props
-  activePanel: PanelId | null
-  onSelectPanel: (id: PanelId) => void
   onTeamsOpen: () => void
   onMyReposOpen: () => void
   onHistoryOpen: () => void
@@ -33,11 +37,21 @@ interface Props {
   profileLoading: boolean
   onUpgrade: () => void
   activeCellRepoPath?: string
+  // panel props (moved from SidePanel)
+  repoPath?: string
+  onWorktreeSelect: (worktreePath: string) => void
+  onNewWorktree: () => void
+  worktreeRefreshKey?: number
+  onRepoLink: () => void
+  onRepoUnlink: () => void
+  onSnippetSend: (content: string) => void
+  onSnippetBroadcast: (content: string) => void
+  onWorkspaceSave: (name: string) => void
+  onWorkspaceLoad: (ws: Workspace) => void
+  onCommandRun: (cmd: string) => void
 }
 
 export default function NavSidebar({
-  activePanel,
-  onSelectPanel,
   onTeamsOpen,
   onMyReposOpen,
   onHistoryOpen,
@@ -50,6 +64,17 @@ export default function NavSidebar({
   profileLoading,
   onUpgrade,
   activeCellRepoPath,
+  repoPath,
+  onWorktreeSelect,
+  onNewWorktree,
+  worktreeRefreshKey,
+  onRepoLink,
+  onRepoUnlink,
+  onSnippetSend,
+  onSnippetBroadcast,
+  onWorkspaceSave,
+  onWorkspaceLoad,
+  onCommandRun,
 }: Props) {
   // ── Update state (ported from ActivityBar) ───────────────────────────────
   const [updateState, setUpdateState] = useState<
@@ -81,23 +106,31 @@ export default function NavSidebar({
 
   const badgeLabel = pendingInvitesCount > 9 ? '9+' : String(pendingInvitesCount)
 
-  function toggle(id: PanelId) {
-    onSelectPanel(id)
-  }
-
   return (
     <aside className="nav-sidebar">
       {/* ── Nav group ───────────────────────────────────────────────────── */}
       <div className="nav-group">
         {/* Worktrees */}
-        <button
-          className={`nav-item${activePanel === 'worktrees' ? ' active' : ''}`}
-          onClick={() => toggle('worktrees')}
-          title="Worktrees"
-        >
-          <GitBranch />
-          <span className="nav-item-label">Worktrees</span>
-        </button>
+        <NavPopover icon={<GitBranch />} label="Worktrees">
+          <SidePanel
+            embedded
+            panel="worktrees"
+            onClose={() => {}}
+            repoPath={repoPath}
+            activeCellRepoPath={activeCellRepoPath}
+            onWorktreeSelect={onWorktreeSelect}
+            onNewWorktree={onNewWorktree}
+            worktreeRefreshKey={worktreeRefreshKey}
+            onRepoLink={onRepoLink}
+            onRepoUnlink={onRepoUnlink}
+            onSnippetSend={onSnippetSend}
+            onSnippetBroadcast={onSnippetBroadcast}
+            onUpgrade={onUpgrade}
+            onWorkspaceSave={onWorkspaceSave}
+            onWorkspaceLoad={onWorkspaceLoad}
+            onCommandRun={onCommandRun}
+          />
+        </NavPopover>
 
         {/* Team */}
         <button
@@ -129,44 +162,34 @@ export default function NavSidebar({
         </button>
 
         {/* Snippets */}
-        <button
-          className={`nav-item${activePanel === 'snippets' ? ' active' : ''}`}
-          onClick={() => toggle('snippets')}
-          title="Snippets"
-        >
-          <SquareCode />
-          <span className="nav-item-label">Snippets</span>
-        </button>
+        <NavPopover icon={<SquareCode />} label="Snippets">
+          <SnippetPanel
+            docked
+            onSend={onSnippetSend}
+            onBroadcast={onSnippetBroadcast}
+            onRequireUpgrade={onUpgrade}
+          />
+        </NavPopover>
 
         {/* MCP */}
-        <button
-          className={`nav-item${activePanel === 'mcp' ? ' active' : ''}`}
-          onClick={() => toggle('mcp')}
-          title="MCP"
-        >
-          <Plug />
-          <span className="nav-item-label">MCP</span>
-        </button>
+        <NavPopover icon={<Plug />} label="MCP">
+          <MCPPanel docked repoPath={repoPath} onRequireUpgrade={onUpgrade} />
+        </NavPopover>
 
         {/* Workspaces */}
-        <button
-          className={`nav-item${activePanel === 'workspaces' ? ' active' : ''}`}
-          onClick={() => toggle('workspaces')}
-          title="Workspaces"
-        >
-          <Layers />
-          <span className="nav-item-label">Workspaces</span>
-        </button>
+        <NavPopover icon={<Layers />} label="Workspaces">
+          <WorkspacePanel
+            docked
+            onSave={onWorkspaceSave}
+            onLoad={onWorkspaceLoad}
+            onRequireUpgrade={onUpgrade}
+          />
+        </NavPopover>
 
         {/* Command History */}
-        <button
-          className={`nav-item${activePanel === 'cmdhist' ? ' active' : ''}`}
-          onClick={() => toggle('cmdhist')}
-          title="Command History"
-        >
-          <SquareTerminal />
-          <span className="nav-item-label">Command History</span>
-        </button>
+        <NavPopover icon={<SquareTerminal />} label="Command History">
+          <CommandHistoryPanel docked onRun={onCommandRun} />
+        </NavPopover>
 
         {/* History */}
         <button

--- a/src/components/NavSidebar.tsx
+++ b/src/components/NavSidebar.tsx
@@ -1,0 +1,277 @@
+import { useState, useEffect } from 'react'
+import {
+  GitBranch,
+  Users,
+  FolderGit2,
+  SquareCode,
+  Plug,
+  Layers,
+  SquareTerminal,
+  Clock,
+  Cable,
+  Plus,
+  Settings,
+} from 'lucide-react'
+import SettingsPanel from './SettingsPanel'
+import UserMenu from './UserMenu'
+import SidePanel from './SidePanel'
+import { supabase } from '../lib/supabase'
+import type { PanelId, Workspace } from '../types'
+
+interface Props {
+  // nav / activity-bar props
+  activePanel: PanelId | null
+  onSelectPanel: (id: PanelId) => void
+  onTeamsOpen: () => void
+  onMyReposOpen: () => void
+  onHistoryOpen: () => void
+  onNewPane: () => void
+  onJoinTerminal: () => void
+  pendingInvitesCount: number
+  plan: 'free' | 'pro' | 'team' | null
+  isTrialActive: boolean
+  trialDaysLeft: number
+  profileLoading: boolean
+  onUpgrade: () => void
+  activeCellRepoPath?: string
+  // side-panel content props
+  repoPath?: string
+  onWorktreeSelect: (worktreePath: string) => void
+  onNewWorktree: () => void
+  worktreeRefreshKey?: number
+  onRepoLink: () => void
+  onRepoUnlink: () => void
+  onSnippetSend: (content: string) => void
+  onSnippetBroadcast: (content: string) => void
+  onWorkspaceSave: (name: string) => void
+  onWorkspaceLoad: (ws: Workspace) => void
+  onCommandRun: (cmd: string) => void
+}
+
+export default function NavSidebar({
+  activePanel,
+  onSelectPanel,
+  onTeamsOpen,
+  onMyReposOpen,
+  onHistoryOpen,
+  onNewPane,
+  onJoinTerminal,
+  pendingInvitesCount,
+  plan,
+  isTrialActive,
+  trialDaysLeft,
+  profileLoading,
+  onUpgrade,
+  activeCellRepoPath,
+  repoPath,
+  onWorktreeSelect,
+  onNewWorktree,
+  worktreeRefreshKey,
+  onRepoLink,
+  onRepoUnlink,
+  onSnippetSend,
+  onSnippetBroadcast,
+  onWorkspaceSave,
+  onWorkspaceLoad,
+  onCommandRun,
+}: Props) {
+  // ── Update state (ported from ActivityBar) ───────────────────────────────
+  const [updateState, setUpdateState] = useState<
+    'idle' | 'checking' | 'up-to-date' | 'update-found' | 'error'
+  >('idle')
+  const [userEmail, setUserEmail] = useState('')
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUserEmail(data.user?.email ?? '')
+    })
+  }, [])
+
+  async function handleCheckUpdates() {
+    if (updateState === 'checking') return
+    setUpdateState('checking')
+    const result = await window.updater.checkForUpdates()
+    if (result === 'up-to-date') {
+      setUpdateState('up-to-date')
+      setTimeout(() => setUpdateState('idle'), 3000)
+    } else if (result === 'update-found') {
+      setUpdateState('update-found')
+      setTimeout(() => setUpdateState('idle'), 4000)
+    } else {
+      setUpdateState('error')
+      setTimeout(() => setUpdateState('idle'), 3000)
+    }
+  }
+
+  const badgeLabel = pendingInvitesCount > 9 ? '9+' : String(pendingInvitesCount)
+
+  function toggle(id: PanelId) {
+    onSelectPanel(id)
+  }
+
+  return (
+    <aside className="nav-sidebar">
+      {/* ── Nav group ───────────────────────────────────────────────────── */}
+      <div className="nav-group">
+        {/* Worktrees */}
+        <button
+          className={`nav-item${activePanel === 'worktrees' ? ' active' : ''}`}
+          onClick={() => toggle('worktrees')}
+          title="Worktrees"
+        >
+          <GitBranch />
+          <span className="nav-item-label">Worktrees</span>
+        </button>
+
+        {/* Team */}
+        <button
+          className="nav-item"
+          onClick={onTeamsOpen}
+          title={
+            pendingInvitesCount > 0
+              ? `Team — ${pendingInvitesCount} pending invite${pendingInvitesCount === 1 ? '' : 's'}`
+              : 'Team'
+          }
+        >
+          <Users />
+          <span className="nav-item-label">Team</span>
+          {pendingInvitesCount > 0 && (
+            <span className="nav-item-badge" aria-label={`${pendingInvitesCount} pending invites`}>
+              {badgeLabel}
+            </span>
+          )}
+        </button>
+
+        {/* My Repos */}
+        <button
+          className="nav-item"
+          onClick={onMyReposOpen}
+          title="My Repos"
+        >
+          <FolderGit2 />
+          <span className="nav-item-label">My Repos</span>
+        </button>
+
+        {/* Snippets */}
+        <button
+          className={`nav-item${activePanel === 'snippets' ? ' active' : ''}`}
+          onClick={() => toggle('snippets')}
+          title="Snippets"
+        >
+          <SquareCode />
+          <span className="nav-item-label">Snippets</span>
+        </button>
+
+        {/* MCP */}
+        <button
+          className={`nav-item${activePanel === 'mcp' ? ' active' : ''}`}
+          onClick={() => toggle('mcp')}
+          title="MCP"
+        >
+          <Plug />
+          <span className="nav-item-label">MCP</span>
+        </button>
+
+        {/* Workspaces */}
+        <button
+          className={`nav-item${activePanel === 'workspaces' ? ' active' : ''}`}
+          onClick={() => toggle('workspaces')}
+          title="Workspaces"
+        >
+          <Layers />
+          <span className="nav-item-label">Workspaces</span>
+        </button>
+
+        {/* Command History */}
+        <button
+          className={`nav-item${activePanel === 'cmdhist' ? ' active' : ''}`}
+          onClick={() => toggle('cmdhist')}
+          title="Command History"
+        >
+          <SquareTerminal />
+          <span className="nav-item-label">Command History</span>
+        </button>
+
+        {/* History */}
+        <button
+          className="nav-item"
+          onClick={onHistoryOpen}
+          title="History"
+        >
+          <Clock />
+          <span className="nav-item-label">History</span>
+        </button>
+
+        {/* Join Terminal */}
+        <button
+          className="nav-item"
+          onClick={onJoinTerminal}
+          title="Join Terminal"
+        >
+          <Cable />
+          <span className="nav-item-label">Join Terminal</span>
+        </button>
+      </div>
+
+      {/* ── Active panel content ─────────────────────────────────────────── */}
+      {activePanel && (
+        <div className="nav-content">
+          <SidePanel
+            embedded
+            panel={activePanel}
+            onClose={() => {}}
+            repoPath={repoPath}
+            activeCellRepoPath={activeCellRepoPath}
+            onWorktreeSelect={onWorktreeSelect}
+            onNewWorktree={onNewWorktree}
+            worktreeRefreshKey={worktreeRefreshKey}
+            onRepoLink={onRepoLink}
+            onRepoUnlink={onRepoUnlink}
+            onSnippetSend={onSnippetSend}
+            onSnippetBroadcast={onSnippetBroadcast}
+            onUpgrade={onUpgrade}
+            onWorkspaceSave={onWorkspaceSave}
+            onWorkspaceLoad={onWorkspaceLoad}
+            onCommandRun={onCommandRun}
+          />
+        </div>
+      )}
+
+      {/* ── Footer ──────────────────────────────────────────────────────── */}
+      <div className="nav-footer">
+        {/* New Terminal */}
+        <button
+          className="nav-item nav-item-primary"
+          onClick={onNewPane}
+          title="New terminal (Ctrl+T)"
+        >
+          <Plus />
+          <span className="nav-item-label">New Terminal</span>
+        </button>
+
+        {/* Settings — wrap so SettingsPanel's transparent trigger overlays the row */}
+        <div className="nav-item" style={{ position: 'relative', cursor: 'pointer' }}>
+          <Settings style={{ width: 17, height: 17, color: 'var(--text-muted)', pointerEvents: 'none', flexShrink: 0 }} />
+          <span className="nav-item-label" style={{ pointerEvents: 'none' }}>Settings</span>
+          <SettingsPanel
+            updateState={updateState}
+            onCheckUpdates={handleCheckUpdates}
+            userEmail={userEmail}
+            activeRepoPath={activeCellRepoPath}
+          />
+        </div>
+
+        {/* Account */}
+        {!profileLoading && (
+          <UserMenu
+            plan={plan}
+            isTrialActive={isTrialActive}
+            trialDaysLeft={trialDaysLeft}
+            onUpgrade={onUpgrade}
+            expanded={true}
+          />
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/src/components/NavSidebar.tsx
+++ b/src/components/NavSidebar.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Settings,
   ChevronRight,
+  Activity,
 } from 'lucide-react'
 import SettingsPanel from './SettingsPanel'
 import UserMenu from './UserMenu'
@@ -21,6 +22,7 @@ import SnippetPanel from './SnippetPanel'
 import MCPPanel from './MCPPanel'
 import WorkspacePanel from './WorkspacePanel'
 import CommandHistoryPanel from './CommandHistoryPanel'
+import SessionPanel from './SessionPanel'
 import { supabase } from '../lib/supabase'
 import type { Workspace } from '../types'
 
@@ -155,6 +157,11 @@ export default function NavSidebar({
             />
           </div>
         )}
+
+        {/* Session — live workspace telemetry (tokens, MCP, worktrees, broadcast) */}
+        <NavPopover icon={<Activity />} label="Session">
+          <SessionPanel docked />
+        </NavPopover>
 
         {/* Team */}
         <button

--- a/src/components/NavSidebar.tsx
+++ b/src/components/NavSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Cable,
   Plus,
   Settings,
+  ChevronRight,
 } from 'lucide-react'
 import SettingsPanel from './SettingsPanel'
 import UserMenu from './UserMenu'
@@ -81,6 +82,9 @@ export default function NavSidebar({
     'idle' | 'checking' | 'up-to-date' | 'update-found' | 'error'
   >('idle')
   const [userEmail, setUserEmail] = useState('')
+  // Worktrees is "working context", not a quick action — it lives inline in the
+  // sidebar as a collapsible accordion (open by default) rather than a popover.
+  const [worktreesOpen, setWorktreesOpen] = useState(true)
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -110,27 +114,47 @@ export default function NavSidebar({
     <aside className="nav-sidebar">
       {/* ── Nav group ───────────────────────────────────────────────────── */}
       <div className="nav-group">
-        {/* Worktrees */}
-        <NavPopover icon={<GitBranch />} label="Worktrees">
-          <SidePanel
-            embedded
-            panel="worktrees"
-            onClose={() => {}}
-            repoPath={repoPath}
-            activeCellRepoPath={activeCellRepoPath}
-            onWorktreeSelect={onWorktreeSelect}
-            onNewWorktree={onNewWorktree}
-            worktreeRefreshKey={worktreeRefreshKey}
-            onRepoLink={onRepoLink}
-            onRepoUnlink={onRepoUnlink}
-            onSnippetSend={onSnippetSend}
-            onSnippetBroadcast={onSnippetBroadcast}
-            onUpgrade={onUpgrade}
-            onWorkspaceSave={onWorkspaceSave}
-            onWorkspaceLoad={onWorkspaceLoad}
-            onCommandRun={onCommandRun}
+        {/* Worktrees — inline collapsible accordion (working context, not a popover) */}
+        <button
+          className={`nav-item${worktreesOpen ? ' active' : ''}`}
+          onClick={() => setWorktreesOpen((v) => !v)}
+          title="Worktrees"
+          aria-expanded={worktreesOpen}
+        >
+          <GitBranch />
+          <span className="nav-item-label">Worktrees</span>
+          <ChevronRight
+            style={{
+              marginLeft: 'auto',
+              width: 15,
+              height: 15,
+              transition: 'transform .15s ease',
+              transform: worktreesOpen ? 'rotate(90deg)' : 'none',
+            }}
           />
-        </NavPopover>
+        </button>
+        {worktreesOpen && (
+          <div className="nav-accordion-body">
+            <SidePanel
+              embedded
+              panel="worktrees"
+              onClose={() => {}}
+              repoPath={repoPath}
+              activeCellRepoPath={activeCellRepoPath}
+              onWorktreeSelect={onWorktreeSelect}
+              onNewWorktree={onNewWorktree}
+              worktreeRefreshKey={worktreeRefreshKey}
+              onRepoLink={onRepoLink}
+              onRepoUnlink={onRepoUnlink}
+              onSnippetSend={onSnippetSend}
+              onSnippetBroadcast={onSnippetBroadcast}
+              onUpgrade={onUpgrade}
+              onWorkspaceSave={onWorkspaceSave}
+              onWorkspaceLoad={onWorkspaceLoad}
+              onCommandRun={onCommandRun}
+            />
+          </div>
+        )}
 
         {/* Team */}
         <button

--- a/src/components/NewPaneDialog.tsx
+++ b/src/components/NewPaneDialog.tsx
@@ -374,7 +374,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
                     padding: '4px 8px',
                     color: '#e2e8f0',
                     fontSize: 11,
-                    fontFamily: 'monospace',
+                    fontFamily: 'var(--font-mono)',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',

--- a/src/components/PRList.tsx
+++ b/src/components/PRList.tsx
@@ -64,7 +64,7 @@ export default function PRList({ repoFullName, githubToken, onSelectPR }: PRList
         const data: GitHubPR[] = await res.json()
         if (alive) {
           setPrs(data)
-          // Detectar stacks solo para PRs open
+          // Detect stacks only for open PRs
           if (filter === 'open') {
             const headMap = new Map<string, GitHubPR>()
             for (const pr of data) headMap.set(pr.head.ref, pr)

--- a/src/components/PRReview.tsx
+++ b/src/components/PRReview.tsx
@@ -225,7 +225,7 @@ Be specific and actionable. Keep it short.`
     }
   }
 
-  // Fetch latest release version cuando se mergea (para sugerir la siguiente)
+  // Fetch latest release version when merged (to suggest the next one)
   useEffect(() => {
     if (!merged || !canMerge) return
     const headers = { Authorization: `Bearer ${githubToken}`, Accept: 'application/vnd.github.v3+json' }
@@ -254,7 +254,7 @@ Be specific and actionable. Keep it short.`
     setReleaseOk(false)
     setBuildTriggered(false)
     try {
-      // 1. Crear el release tag en GitHub
+      // 1. Create the release tag on GitHub
       const tagName = version.startsWith('v') ? version : `v${version}`
       const relRes = await fetch(`https://api.github.com/repos/${repoFullName}/releases`, {
         method: 'POST',

--- a/src/components/PaneHeader.tsx
+++ b/src/components/PaneHeader.tsx
@@ -194,7 +194,7 @@ export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChang
         <button className="pane-copy-btn" onClick={handleCopy} title="Copy last response">
           {copied ? (
             <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-              <path d="M2 6l3 3 5-5" stroke="#22C55E" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M2 6l3 3 5-5" stroke="var(--color-success)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
           ) : (
             <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
@@ -209,7 +209,7 @@ export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChang
         <button className="pane-save-btn" onClick={handleSave} title="Save conversation to history">
           {saved ? (
             <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-              <path d="M2 6l3 3 5-5" stroke="#22C55E" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M2 6l3 3 5-5" stroke="var(--color-success)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
           ) : (
             <svg width="11" height="11" viewBox="0 0 12 12" fill="none">

--- a/src/components/RepoPicker.tsx
+++ b/src/components/RepoPicker.tsx
@@ -185,8 +185,8 @@ export default function RepoPicker({ githubToken, gitlabToken, excludedFullNames
                 padding: '4px 12px',
                 fontSize: 12,
                 borderRadius: 12,
-                border: '1px solid var(--border-color, #ccc)',
-                background: provider === 'github' ? 'var(--raven-blue, #0066FF)' : 'transparent',
+                border: '1px solid var(--border)',
+                background: provider === 'github' ? 'var(--accent)' : 'transparent',
                 color: provider === 'github' ? '#fff' : 'inherit',
                 cursor: 'pointer',
               }}
@@ -200,8 +200,8 @@ export default function RepoPicker({ githubToken, gitlabToken, excludedFullNames
                 padding: '4px 12px',
                 fontSize: 12,
                 borderRadius: 12,
-                border: '1px solid var(--border-color, #ccc)',
-                background: provider === 'gitlab' ? 'var(--raven-blue, #0066FF)' : 'transparent',
+                border: '1px solid var(--border)',
+                background: provider === 'gitlab' ? 'var(--accent)' : 'transparent',
                 color: provider === 'gitlab' ? '#fff' : 'inherit',
                 cursor: 'pointer',
               }}

--- a/src/components/SessionPanel.tsx
+++ b/src/components/SessionPanel.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+
+interface Props {
+  docked?: boolean
+}
+
+// NOTE: Representative session data for the design pass. CPU/mem/ports/worktrees
+// and MCP server lists are already tracked in the app (window.metrics / MCP hooks)
+// and will be wired in here next; token throughput + cost need new instrumentation
+// (counting tokens per AI pane), which is a scoped follow-up.
+const METRICS = [
+  { label: 'TOKENS · 1H', value: '184.2', unit: 'k', delta: '▲ 22%', tone: 'up' },
+  { label: 'PEAK', value: '3.1', unit: 'k/s', delta: '12:03', tone: 'flat' },
+  { label: 'PANES', value: '4', unit: '', delta: 'Claude · Gemini', tone: 'flat' },
+  { label: 'COST · 1H', value: '$2.41', unit: '', delta: '▲ opus', tone: 'warn' },
+] as const
+
+// sparkline heights (0–100) — throughput over the last few minutes
+const SPARK = [30, 52, 41, 70, 58, 88, 64, 95, 72, 50, 80, 66, 92, 74]
+
+const MCP = [
+  { name: 'filesystem', scope: 'project', latency: '18ms', status: 'ok' },
+  { name: 'github', scope: 'global', latency: '142ms', status: 'ok' },
+  { name: 'postgres', scope: 'project', latency: '34ms', status: 'ok' },
+  { name: 'puppeteer', scope: 'global', latency: '612ms', status: 'slow' },
+  { name: 'playwright', scope: 'project', latency: '—', status: 'idle' },
+] as const
+
+const WORKTREES = [
+  { name: 'feat/auth-rewrite', ahead: '↑2 ↓0', diff: '+42 −12', state: 'active' },
+  { name: 'main', ahead: '↑0 ↓0', diff: 'clean', state: 'clean' },
+  { name: 'fix/rate-limit', ahead: '↑2 ↓1', diff: '+8', state: 'behind' },
+  { name: 'spike/edge-cache', ahead: '↑0 ↓4', diff: 'stash·2', state: 'stashed' },
+] as const
+
+const CAST = [
+  { pane: 'Claude', model: 'opus', state: 'delivered' },
+  { pane: 'Gemini', model: '2.0-pro', state: 'delivered' },
+  { pane: 'zsh', model: 'shell', state: 'skipped' },
+] as const
+
+type Tab = 'mcp' | 'git' | 'cast'
+
+export default function SessionPanel({ docked }: Props) {
+  const [tab, setTab] = useState<Tab>('mcp')
+
+  const body = (
+    <>
+      <div className="session-head">
+        <span className="session-title">Session</span>
+        <span className="session-live"><span className="session-live-dot" />live</span>
+        <span className="session-uptime">1h 04m</span>
+      </div>
+
+      <div className="session-metrics">
+        {METRICS.map((m) => (
+          <div key={m.label} className="session-metric">
+            <div className="session-metric-label">{m.label}</div>
+            <div className="session-metric-value">{m.value}<small>{m.unit}</small></div>
+            <div className={`session-metric-delta ${m.tone}`}>{m.delta}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="session-spark-head">THROUGHPUT · tok/s</div>
+      <div className="session-spark">
+        {SPARK.map((h, i) => (
+          <i key={i} style={{ height: `${h}%` }} />
+        ))}
+      </div>
+
+      <div className="session-tabs">
+        <button className={`session-tab${tab === 'mcp' ? ' active' : ''}`} onClick={() => setTab('mcp')}>MCP · 5</button>
+        <button className={`session-tab${tab === 'git' ? ' active' : ''}`} onClick={() => setTab('git')}>Worktrees · 4</button>
+        <button className={`session-tab${tab === 'cast' ? ' active' : ''}`} onClick={() => setTab('cast')}>Broadcast</button>
+      </div>
+
+      <div className="session-list">
+        {tab === 'mcp' && MCP.map((s) => (
+          <div key={s.name} className="session-row">
+            <span className={`session-pip ${s.status}`} />
+            <span className="session-row-name">{s.name}</span>
+            <span className="session-row-meta">{s.scope}</span>
+            <span className="session-row-val">{s.latency}</span>
+          </div>
+        ))}
+        {tab === 'git' && WORKTREES.map((w) => (
+          <div key={w.name} className="session-row">
+            <span className={`session-pip ${w.state === 'active' ? 'ok' : w.state === 'behind' ? 'slow' : 'idle'}`} />
+            <span className="session-row-name">{w.name}</span>
+            <span className="session-row-meta">{w.ahead}</span>
+            <span className="session-row-val">{w.diff}</span>
+          </div>
+        ))}
+        {tab === 'cast' && CAST.map((c) => (
+          <div key={c.pane} className="session-row">
+            <span className={`session-pip ${c.state === 'delivered' ? 'ok' : 'idle'}`} />
+            <span className="session-row-name">{c.pane}</span>
+            <span className="session-row-meta">{c.model}</span>
+            <span className="session-row-val">{c.state}</span>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+
+  if (docked) {
+    return <div className="session-panel session-panel--docked">{body}</div>
+  }
+  return <div className="session-panel">{body}</div>
+}

--- a/src/components/SharedTerminalViewer.tsx
+++ b/src/components/SharedTerminalViewer.tsx
@@ -148,7 +148,7 @@ export default function SharedTerminalViewer({ onClose }: Props) {
       } as React.CSSProperties}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
           <span style={{ fontSize: 11, color: waitingApproval ? '#eab308' : '#22c55e', fontWeight: 600 }}>● {waitingApproval ? 'Pending' : 'Live'}</span>
-          <span style={{ fontSize: 12, color: 'var(--text-muted)', letterSpacing: 2, fontFamily: 'monospace' }}>
+          <span style={{ fontSize: 12, color: 'var(--text-muted)', letterSpacing: 2, fontFamily: 'var(--font-mono)' }}>
             {code}
           </span>
           <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>— {waitingApproval ? 'Waiting for approval' : 'Interactive'}</span>

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import { GitFork, GitBranch, Github, X, Check, Plus, PanelLeftClose } from 'lucide-react'
+import { GitFork, GitBranch, ExternalLink, X, Check, Plus, PanelLeftClose } from 'lucide-react'
 import { PanelId, Workspace } from '../types'
 import { useGitInfo } from '../hooks/useGitInfo'
 import { basename } from '../lib/path'
@@ -79,7 +79,7 @@ function WorktreesBody({
               title="Open on GitHub"
               onClick={() => window.electronShell.openExternal(githubUrl)}
             >
-              <Github />
+              <ExternalLink />
             </button>
           )}
           <button
@@ -113,7 +113,7 @@ function WorktreesBody({
   )
 }
 
-export function SidePanel({
+export default function SidePanel({
   panel,
   onClose,
   repoPath,

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -11,6 +11,7 @@ import CommandHistoryPanel from './CommandHistoryPanel'
 interface Props {
   panel: PanelId
   onClose: () => void
+  embedded?: boolean
   // worktrees
   repoPath?: string
   activeCellRepoPath?: string
@@ -116,6 +117,7 @@ function WorktreesBody({
 export default function SidePanel({
   panel,
   onClose,
+  embedded,
   repoPath,
   activeCellRepoPath,
   onWorktreeSelect,
@@ -130,6 +132,57 @@ export default function SidePanel({
   onWorkspaceLoad,
   onCommandRun,
 }: Props) {
+  const content = (
+    <>
+      {panel === 'worktrees' && (
+        <WorktreesBody
+          repoPath={repoPath}
+          activeCellRepoPath={activeCellRepoPath}
+          onWorktreeSelect={onWorktreeSelect}
+          onNewWorktree={onNewWorktree}
+          worktreeRefreshKey={worktreeRefreshKey}
+          onRepoLink={onRepoLink}
+          onRepoUnlink={onRepoUnlink}
+        />
+      )}
+
+      {panel === 'snippets' && (
+        <SnippetPanel
+          docked
+          onSend={onSnippetSend}
+          onBroadcast={onSnippetBroadcast}
+          onRequireUpgrade={onUpgrade}
+        />
+      )}
+
+      {panel === 'mcp' && (
+        <MCPPanel
+          docked
+          repoPath={repoPath}
+          onRequireUpgrade={onUpgrade}
+        />
+      )}
+
+      {panel === 'workspaces' && (
+        <WorkspacePanel
+          docked
+          onSave={onWorkspaceSave}
+          onLoad={onWorkspaceLoad}
+          onRequireUpgrade={onUpgrade}
+        />
+      )}
+
+      {panel === 'cmdhist' && (
+        <CommandHistoryPanel
+          docked
+          onRun={onCommandRun}
+        />
+      )}
+    </>
+  )
+
+  if (embedded) return content
+
   return (
     <div className="side-panel">
       <div className="side-panel-head">
@@ -142,50 +195,7 @@ export default function SidePanel({
       </div>
 
       <div className="side-panel-body">
-        {panel === 'worktrees' && (
-          <WorktreesBody
-            repoPath={repoPath}
-            activeCellRepoPath={activeCellRepoPath}
-            onWorktreeSelect={onWorktreeSelect}
-            onNewWorktree={onNewWorktree}
-            worktreeRefreshKey={worktreeRefreshKey}
-            onRepoLink={onRepoLink}
-            onRepoUnlink={onRepoUnlink}
-          />
-        )}
-
-        {panel === 'snippets' && (
-          <SnippetPanel
-            docked
-            onSend={onSnippetSend}
-            onBroadcast={onSnippetBroadcast}
-            onRequireUpgrade={onUpgrade}
-          />
-        )}
-
-        {panel === 'mcp' && (
-          <MCPPanel
-            docked
-            repoPath={repoPath}
-            onRequireUpgrade={onUpgrade}
-          />
-        )}
-
-        {panel === 'workspaces' && (
-          <WorkspacePanel
-            docked
-            onSave={onWorkspaceSave}
-            onLoad={onWorkspaceLoad}
-            onRequireUpgrade={onUpgrade}
-          />
-        )}
-
-        {panel === 'cmdhist' && (
-          <CommandHistoryPanel
-            docked
-            onRun={onCommandRun}
-          />
-        )}
+        {content}
       </div>
     </div>
   )

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,0 +1,188 @@
+import { GitFork, GitBranch, Github, X, Check, Plus, PanelLeftClose } from 'lucide-react'
+import { PanelId, Workspace } from '../types'
+import { useGitInfo } from '../hooks/useGitInfo'
+import { basename } from '../lib/path'
+import { WorktreesSection } from './WorktreesSection'
+import SnippetPanel from './SnippetPanel'
+import MCPPanel from './MCPPanel'
+import WorkspacePanel from './WorkspacePanel'
+import CommandHistoryPanel from './CommandHistoryPanel'
+
+interface Props {
+  panel: PanelId
+  onClose: () => void
+  // worktrees
+  repoPath?: string
+  activeCellRepoPath?: string
+  onWorktreeSelect: (worktreePath: string) => void
+  onNewWorktree: () => void
+  worktreeRefreshKey?: number
+  onRepoLink: () => void
+  onRepoUnlink: () => void
+  // snippets
+  onSnippetSend: (content: string) => void
+  onSnippetBroadcast: (content: string) => void
+  // shared
+  onUpgrade: () => void
+  // workspaces
+  onWorkspaceSave: (name: string) => void
+  onWorkspaceLoad: (ws: Workspace) => void
+  // cmdhist
+  onCommandRun: (cmd: string) => void
+}
+
+const PANEL_TITLES: Record<PanelId, string> = {
+  worktrees: 'Worktrees',
+  snippets: 'Snippets',
+  mcp: 'MCP',
+  workspaces: 'Workspaces',
+  cmdhist: 'Command History',
+}
+
+function WorktreesBody({
+  repoPath,
+  activeCellRepoPath,
+  onWorktreeSelect,
+  onNewWorktree,
+  worktreeRefreshKey,
+  onRepoLink,
+  onRepoUnlink,
+}: {
+  repoPath?: string
+  activeCellRepoPath?: string
+  onWorktreeSelect: (p: string) => void
+  onNewWorktree: () => void
+  worktreeRefreshKey?: number
+  onRepoLink: () => void
+  onRepoUnlink: () => void
+}) {
+  const { branch, githubUrl, isDirty } = useGitInfo(repoPath)
+
+  if (!repoPath) {
+    return (
+      <button className="side-panel-link" onClick={onRepoLink}>
+        <Plus size={14} />
+        Link a repository…
+      </button>
+    )
+  }
+
+  return (
+    <>
+      <div className="repo-card">
+        <div className="repo-card-top">
+          <GitFork className="gi" />
+          <span className="repo-card-name">{basename(repoPath)}</span>
+          {githubUrl && (
+            <button
+              className="repo-card-ext"
+              title="Open on GitHub"
+              onClick={() => window.electronShell.openExternal(githubUrl)}
+            >
+              <Github />
+            </button>
+          )}
+          <button
+            className="repo-card-ext"
+            title="Unlink repository"
+            onClick={onRepoUnlink}
+          >
+            <X />
+          </button>
+        </div>
+        <div className="repo-card-meta">
+          <span className={`branch-pill${isDirty ? ' dirty' : ''}`}>
+            <GitBranch />
+            {branch ?? '—'}
+            {isDirty && ' ●'}
+          </span>
+          <span className="repo-sync">
+            <Check />
+            up to date
+          </span>
+        </div>
+      </div>
+      <WorktreesSection
+        repoPath={repoPath}
+        activeRepoPath={activeCellRepoPath}
+        onSelect={onWorktreeSelect}
+        onNewClick={onNewWorktree}
+        refreshKey={worktreeRefreshKey}
+      />
+    </>
+  )
+}
+
+export function SidePanel({
+  panel,
+  onClose,
+  repoPath,
+  activeCellRepoPath,
+  onWorktreeSelect,
+  onNewWorktree,
+  worktreeRefreshKey,
+  onRepoLink,
+  onRepoUnlink,
+  onSnippetSend,
+  onSnippetBroadcast,
+  onUpgrade,
+  onWorkspaceSave,
+  onWorkspaceLoad,
+  onCommandRun,
+}: Props) {
+  return (
+    <div className="side-panel">
+      <div className="side-panel-head">
+        <span className="ttl">{PANEL_TITLES[panel]}</span>
+        <div className="acts">
+          <button className="side-panel-act" title="Close panel" onClick={onClose}>
+            <PanelLeftClose />
+          </button>
+        </div>
+      </div>
+
+      <div className="side-panel-body">
+        {panel === 'worktrees' && (
+          <WorktreesBody
+            repoPath={repoPath}
+            activeCellRepoPath={activeCellRepoPath}
+            onWorktreeSelect={onWorktreeSelect}
+            onNewWorktree={onNewWorktree}
+            worktreeRefreshKey={worktreeRefreshKey}
+            onRepoLink={onRepoLink}
+            onRepoUnlink={onRepoUnlink}
+          />
+        )}
+
+        {panel === 'snippets' && (
+          <SnippetPanel
+            onSend={onSnippetSend}
+            onBroadcast={onSnippetBroadcast}
+            onRequireUpgrade={onUpgrade}
+          />
+        )}
+
+        {panel === 'mcp' && (
+          <MCPPanel
+            repoPath={repoPath}
+            onRequireUpgrade={onUpgrade}
+          />
+        )}
+
+        {panel === 'workspaces' && (
+          <WorkspacePanel
+            onSave={onWorkspaceSave}
+            onLoad={onWorkspaceLoad}
+            onRequireUpgrade={onUpgrade}
+          />
+        )}
+
+        {panel === 'cmdhist' && (
+          <CommandHistoryPanel
+            onRun={onCommandRun}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -156,6 +156,7 @@ export default function SidePanel({
 
         {panel === 'snippets' && (
           <SnippetPanel
+            docked
             onSend={onSnippetSend}
             onBroadcast={onSnippetBroadcast}
             onRequireUpgrade={onUpgrade}
@@ -164,6 +165,7 @@ export default function SidePanel({
 
         {panel === 'mcp' && (
           <MCPPanel
+            docked
             repoPath={repoPath}
             onRequireUpgrade={onUpgrade}
           />
@@ -171,6 +173,7 @@ export default function SidePanel({
 
         {panel === 'workspaces' && (
           <WorkspacePanel
+            docked
             onSave={onWorkspaceSave}
             onLoad={onWorkspaceLoad}
             onRequireUpgrade={onUpgrade}
@@ -179,6 +182,7 @@ export default function SidePanel({
 
         {panel === 'cmdhist' && (
           <CommandHistoryPanel
+            docked
             onRun={onCommandRun}
           />
         )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -489,7 +489,7 @@ export default function Sidebar({
                   alignItems: 'center',
                   justifyContent: 'center',
                   lineHeight: 1,
-                  boxShadow: '0 0 0 1.5px var(--bg-primary, #0a0a0a)',
+                  boxShadow: '0 0 0 1.5px var(--bg-sidebar)',
                 }}
               >
                 {pendingInvitesCount > 9 ? '9+' : pendingInvitesCount}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -239,7 +239,7 @@ export default function Sidebar({
               }}
               style={{
                 width: '100%',
-                background: joinInput.length >= 8 ? '#0066FF' : 'var(--bg-elevated)',
+                background: joinInput.length >= 8 ? 'var(--accent)' : 'var(--bg-elevated)',
                 color: joinInput.length >= 8 ? '#fff' : 'var(--text-muted)',
                 border: 'none',
                 borderRadius: 6,

--- a/src/components/SnippetPanel.tsx
+++ b/src/components/SnippetPanel.tsx
@@ -10,6 +10,7 @@ interface Props {
   onSend: (content: string) => void
   onBroadcast: (content: string) => void
   onRequireUpgrade?: () => void
+  docked?: boolean
 }
 
 interface VarModal {
@@ -30,7 +31,7 @@ function substituteVars(content: string, values: Record<string, string>): string
   return content.replace(/\{\{(\w+)\}\}/g, (_, key) => values[key] ?? `{{${key}}}`)
 }
 
-export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: Props) {
+export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade, docked }: Props) {
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<'mine' | 'team'>('mine')
   const [snippets, setSnippets] = useState<Snippet[]>([])
@@ -47,11 +48,11 @@ export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: 
   const { plan } = useProfile()
 
   useEffect(() => {
-    window.snippets.list().then(setSnippets)
-  }, [open])
+    if (open || docked) window.snippets.list().then(setSnippets)
+  }, [open, docked])
 
   useEffect(() => {
-    if (!open) return
+    if (!open || docked) return
     const handler = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setOpen(false)
@@ -60,7 +61,7 @@ export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: 
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [open])
+  }, [open, docked])
 
   const save = async () => {
     if (!name.trim() || !content.trim()) return
@@ -87,7 +88,7 @@ export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: 
     if (vars.length === 0) {
       if (mode === 'send') onSend(snippetContent)
       else onBroadcast(snippetContent)
-      setOpen(false)
+      if (!docked) setOpen(false)
       return
     }
     const values: Record<string, string> = {}
@@ -101,100 +102,87 @@ export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: 
     if (varModal.mode === 'send') onSend(result)
     else onBroadcast(result)
     setVarModal(null)
-    setOpen(false)
+    if (!docked) setOpen(false)
   }
 
-  return (
-    <div className="snippet-wrap" ref={panelRef}>
-      <button
-        className={`titlebar-btn${open ? ' active' : ''}`}
-        onClick={() => { setOpen((v) => !v); setCreating(false) }}
-        title="Snippets"
-      >
-        <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-          <rect x="1" y="1" width="12" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
-          <rect x="1" y="5.5" width="8" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
-          <rect x="1" y="10" width="10" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
-        </svg>
-        Snippets
-      </button>
-
-      {open && popPos && (
-        <div ref={popoverRef} className="snippet-panel" style={{ position: 'fixed', top: popPos.top, left: popPos.left, right: 'auto' }}>
-          <div className="snippet-panel-header">
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button className={`workspace-tab-btn${tab === 'mine' ? ' active' : ''}`} onClick={() => setTab('mine')}>Mine</button>
-              <button className={`workspace-tab-btn${tab === 'team' ? ' active' : ''}`} onClick={() => { setTab('team'); refreshShared() }}>Team</button>
-            </div>
-            {tab === 'mine' && (
-              <button className="snippet-add-btn" onClick={() => setCreating((v) => !v)} title="New snippet">+</button>
-            )}
-          </div>
-
-          {tab === 'mine' && (
-            <>
-              {creating && (
-                <div className="snippet-form">
-                  <input className="snippet-input" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
-                  <textarea
-                    className="snippet-textarea"
-                    placeholder="Content… Use {{variable}} for dynamic values"
-                    value={content}
-                    onChange={(e) => setContent(e.target.value)}
-                    rows={4}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) save()
-                      if (e.key === 'Escape') setCreating(false)
-                    }}
-                  />
-                  <div className="snippet-form-actions">
-                    <button className="snippet-save-btn" onClick={save}>Save</button>
-                    <button className="snippet-cancel-btn" onClick={() => setCreating(false)}>Cancel</button>
-                  </div>
-                </div>
-              )}
-              {snippets.length === 0 && !creating && (
-                <p className="snippet-empty">No snippets yet. Click + to create one.</p>
-              )}
-              <div className="snippet-list">
-                {snippets.map((s) => (
-                  <div key={s.id} className="snippet-item">
-                    <span className="snippet-name" title={s.content}>{s.name}</span>
-                    <div className="snippet-item-actions">
-                      <button className="snippet-send-btn" onClick={() => handleSend(s.content, 'send')} title="Send to active terminal">Send</button>
-                      <button className="snippet-broadcast-btn" onClick={() => handleSend(s.content, 'broadcast')} title="Broadcast to all">All</button>
-                      <button className="snippet-send-btn" onClick={() => handleShare(s.name, s.content)} title={team ? 'Share to Team' : 'Share to Community'}>↗</button>
-                      <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: s.id, name: s.name })} title="Delete">×</button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-
-          {tab === 'team' && (
-            <>
-              {sharedLoading && <p className="snippet-empty">Loading…</p>}
-              {!sharedLoading && shared.length === 0 && <p className="snippet-empty">No team snippets yet.</p>}
-              <div className="snippet-list">
-                {shared.map((s) => (
-                  <div key={s.id} className="snippet-item">
-                    <span className="snippet-name" title={s.content}>{s.name}</span>
-                    <div className="snippet-item-actions">
-                      <button className="snippet-send-btn" onClick={() => handleSend(s.content, 'send')} title="Send">Send</button>
-                      <button className="snippet-broadcast-btn" onClick={() => handleSend(s.content, 'broadcast')} title="Broadcast">All</button>
-                      {s.owner_id === userId && (
-                        <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: s.id, name: s.name, shared: true })} title="Remove">×</button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
+  const body = (
+    <>
+      <div className="snippet-panel-header">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className={`workspace-tab-btn${tab === 'mine' ? ' active' : ''}`} onClick={() => setTab('mine')}>Mine</button>
+          <button className={`workspace-tab-btn${tab === 'team' ? ' active' : ''}`} onClick={() => { setTab('team'); refreshShared() }}>Team</button>
         </div>
+        {tab === 'mine' && (
+          <button className="snippet-add-btn" onClick={() => setCreating((v) => !v)} title="New snippet">+</button>
+        )}
+      </div>
+
+      {tab === 'mine' && (
+        <>
+          {creating && (
+            <div className="snippet-form">
+              <input className="snippet-input" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+              <textarea
+                className="snippet-textarea"
+                placeholder="Content… Use {{variable}} for dynamic values"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={4}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) save()
+                  if (e.key === 'Escape') setCreating(false)
+                }}
+              />
+              <div className="snippet-form-actions">
+                <button className="snippet-save-btn" onClick={save}>Save</button>
+                <button className="snippet-cancel-btn" onClick={() => setCreating(false)}>Cancel</button>
+              </div>
+            </div>
+          )}
+          {snippets.length === 0 && !creating && (
+            <p className="snippet-empty">No snippets yet. Click + to create one.</p>
+          )}
+          <div className="snippet-list">
+            {snippets.map((s) => (
+              <div key={s.id} className="snippet-item">
+                <span className="snippet-name" title={s.content}>{s.name}</span>
+                <div className="snippet-item-actions">
+                  <button className="snippet-send-btn" onClick={() => handleSend(s.content, 'send')} title="Send to active terminal">Send</button>
+                  <button className="snippet-broadcast-btn" onClick={() => handleSend(s.content, 'broadcast')} title="Broadcast to all">All</button>
+                  <button className="snippet-send-btn" onClick={() => handleShare(s.name, s.content)} title={team ? 'Share to Team' : 'Share to Community'}>↗</button>
+                  <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: s.id, name: s.name })} title="Delete">×</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
       )}
 
+      {tab === 'team' && (
+        <>
+          {sharedLoading && <p className="snippet-empty">Loading…</p>}
+          {!sharedLoading && shared.length === 0 && <p className="snippet-empty">No team snippets yet.</p>}
+          <div className="snippet-list">
+            {shared.map((s) => (
+              <div key={s.id} className="snippet-item">
+                <span className="snippet-name" title={s.content}>{s.name}</span>
+                <div className="snippet-item-actions">
+                  <button className="snippet-send-btn" onClick={() => handleSend(s.content, 'send')} title="Send">Send</button>
+                  <button className="snippet-broadcast-btn" onClick={() => handleSend(s.content, 'broadcast')} title="Broadcast">All</button>
+                  {s.owner_id === userId && (
+                    <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: s.id, name: s.name, shared: true })} title="Remove">×</button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  )
+
+  const modals = (
+    <>
       {varModal && (
         <div className="confirm-overlay" onClick={() => setVarModal(null)}>
           <div className="confirm-dialog" onClick={(e) => e.stopPropagation()} style={{ minWidth: 280 }}>
@@ -240,6 +228,40 @@ export default function SnippetPanel({ onSend, onBroadcast, onRequireUpgrade }: 
           onCancel={() => setConfirmDelete(null)}
         />
       )}
+    </>
+  )
+
+  if (docked) {
+    return (
+      <>
+        <div className="snippet-panel snippet-panel--docked">{body}</div>
+        {modals}
+      </>
+    )
+  }
+
+  return (
+    <div className="snippet-wrap" ref={panelRef}>
+      <button
+        className={`titlebar-btn${open ? ' active' : ''}`}
+        onClick={() => { setOpen((v) => !v); setCreating(false) }}
+        title="Snippets"
+      >
+        <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+          <rect x="1" y="1" width="12" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+          <rect x="1" y="5.5" width="8" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+          <rect x="1" y="10" width="10" height="3" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+        </svg>
+        Snippets
+      </button>
+
+      {open && popPos && (
+        <div ref={popoverRef} className="snippet-panel" style={{ position: 'fixed', top: popPos.top, left: popPos.left, right: 'auto' }}>
+          {body}
+        </div>
+      )}
+
+      {modals}
     </div>
   )
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,17 @@
+interface StatusBarProps {
+  paneCount: number
+  workspaceName: string
+  repoName?: string
+}
+
+export default function StatusBar({ paneCount, workspaceName, repoName }: StatusBarProps) {
+  return (
+    <div className="status-bar">
+      <span className="status-item">{workspaceName}</span>
+      {repoName && <span className="status-item">⎇ {repoName}</span>}
+      <span className="status-item status-item-end">
+        {paneCount} {paneCount === 1 ? 'pane' : 'panes'}
+      </span>
+    </div>
+  )
+}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -60,7 +60,7 @@ const SortableTab = memo(function SortableTab({
     setRenamingId(null)
   }
 
-  const tabAccent = tab.accentColor ?? '#0066FF'
+  const tabAccent = tab.accentColor ?? 'var(--accent)'
 
   // Only apply transition while actively dragging — otherwise React re-renders
   // (from upstream metrics polling) re-attach the style and trigger CSS

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -187,7 +187,7 @@ export default function TabBar({
         </SortableContext>
       </DndContext>
 
-      <button className="tab-new" onClick={onTabNew} title="Nuevo workspace">
+      <button className="tab-new" onClick={onTabNew} title="New workspace">
         +
       </button>
 

--- a/src/components/TeamChat.tsx
+++ b/src/components/TeamChat.tsx
@@ -19,7 +19,7 @@ const REACTION_EMOJIS = ['👍', '❤️', '🔥', '👀', '🎉']
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
   const mins = Math.floor(diff / 60000)
-  if (mins < 1) return 'ahora'
+  if (mins < 1) return 'now'
   if (mins < 60) return `${mins}m`
   const hrs = Math.floor(mins / 60)
   if (hrs < 24) return `${hrs}h`
@@ -199,7 +199,7 @@ export default function TeamChat({
           onClick={handlePost}
           disabled={posting || !messageInput.trim()}
         >
-          {posting ? '…' : 'Enviar'}
+          {posting ? '…' : 'Send'}
         </button>
       </div>
     </div>

--- a/src/components/TeamsWorkspace.tsx
+++ b/src/components/TeamsWorkspace.tsx
@@ -1286,7 +1286,7 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
                         }}>
                           {m.email.charAt(0).toUpperCase()}
                         </div>
-                        <div className="tw-presence-dot" style={{ background: isOnline ? '#22C55E' : '#555' }} />
+                        <div className="tw-presence-dot" style={{ background: isOnline ? 'var(--color-success)' : 'var(--text-muted)' }} />
                       </div>
                       <div className="tw-presence-info">
                         <div className="tw-presence-email">{m.email}</div>

--- a/src/components/TeamsWorkspace.tsx
+++ b/src/components/TeamsWorkspace.tsx
@@ -1243,7 +1243,7 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
                       <div key={mc.id} className="snippet-item">
                         <div style={{ flex: 1, minWidth: 0 }}>
                           <span className="snippet-name" style={{ display: 'block' }}>{mc.name}</span>
-                          <span style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+                          <span style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
                             {typeof mc.config.command === 'string' ? mc.config.command : ''}
                           </span>
                         </div>

--- a/src/components/VoiceOrb.tsx
+++ b/src/components/VoiceOrb.tsx
@@ -23,7 +23,7 @@ export default function VoiceOrb({ isListening, interimTranscript, onClick }: Vo
     }}>
       <div
         onClick={onClick}
-        title={isListening ? 'Click para detener' : 'Click para hablar'}
+        title={isListening ? 'Click to stop' : 'Click to speak'}
         style={{
           width: size,
           height: size,

--- a/src/components/WorkspacePanel.tsx
+++ b/src/components/WorkspacePanel.tsx
@@ -10,6 +10,7 @@ interface Props {
   onSave: (name: string) => void
   onLoad: (ws: Workspace) => void
   onRequireUpgrade?: () => void
+  docked?: boolean
 }
 
 function makePane(aiType: keyof typeof AI_CONFIG): SessionPane {
@@ -97,7 +98,7 @@ const TEMPLATES: { name: string; description: string; build: () => Omit<Workspac
   },
 ]
 
-export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Props) {
+export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade, docked }: Props) {
   const [open, setOpen] = useState(false)
   const [tab, setTab] = useState<'mine' | 'team' | 'templates'>('mine')
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
@@ -112,16 +113,16 @@ export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Pro
   const { plan } = useProfile()
 
   useEffect(() => {
-    if (open) {
+    if (open || docked) {
       window.workspaces.list().then(setWorkspaces)
       refreshShared()
     } else {
       setSaving(false)
     }
-  }, [open])
+  }, [open, docked])
 
   useEffect(() => {
-    if (!open) return
+    if (!open || docked) return
     const handler = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         setOpen(false)
@@ -129,7 +130,7 @@ export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Pro
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [open])
+  }, [open, docked])
 
   const handleSave = () => {
     if (!name.trim()) return
@@ -141,7 +142,7 @@ export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Pro
 
   const handleLoad = (ws: Workspace) => {
     onLoad(ws)
-    setOpen(false)
+    if (!docked) setOpen(false)
   }
 
   const handleDelete = async (id: string) => {
@@ -184,7 +185,134 @@ export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Pro
     await window.workspaces.save(ws)
     setWorkspaces(prev => [...prev, ws])
     onLoad(ws)
-    setOpen(false)
+    if (!docked) setOpen(false)
+  }
+
+  const body = (
+    <>
+      <div className="snippet-panel-header">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            className={`workspace-tab-btn${tab === 'mine' ? ' active' : ''}`}
+            onClick={() => setTab('mine')}
+          >Mine</button>
+          <button
+            className={`workspace-tab-btn${tab === 'team' ? ' active' : ''}`}
+            onClick={() => { setTab('team'); refreshShared() }}
+          >Team</button>
+          <button
+            className={`workspace-tab-btn${tab === 'templates' ? ' active' : ''}`}
+            onClick={() => setTab('templates')}
+          >Templates</button>
+        </div>
+        {tab === 'mine' && (
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button className="snippet-add-btn" onClick={(e) => { e.stopPropagation(); handleImport() }} title="Import from file">↑</button>
+            <button className="snippet-add-btn" onClick={(e) => { e.stopPropagation(); setSaving((v) => !v) }} title="Save current workspace">+</button>
+          </div>
+        )}
+      </div>
+
+      {tab === 'mine' && (
+        <>
+          {saving && (
+            <div className="snippet-form">
+              <input
+                className="snippet-input"
+                placeholder="Workspace name…"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleSave()
+                  if (e.key === 'Escape') setSaving(false)
+                }}
+              />
+              <div className="snippet-form-actions">
+                <button className="snippet-save-btn" onClick={handleSave}>Save</button>
+                <button className="snippet-cancel-btn" onClick={() => setSaving(false)}>Cancel</button>
+              </div>
+            </div>
+          )}
+          {workspaces.length === 0 && !saving && (
+            <p className="snippet-empty">No workspaces. Click + to save the current layout.</p>
+          )}
+          <div className="snippet-list">
+            {workspaces.map((ws) => (
+              <div key={ws.id} className="snippet-item">
+                <span className="snippet-name" title={`${ws.layout.rows}×${ws.layout.cols}`}>{ws.name}</span>
+                <div className="snippet-item-actions">
+                  <button className="snippet-send-btn" onClick={() => handleLoad(ws)} title="Load">Load</button>
+                  <button className="snippet-send-btn" onClick={() => handleShare(ws)} title={team ? 'Share to Team' : 'Share to Community'}>↗</button>
+                  <button className="snippet-send-btn" onClick={() => handleExport(ws)} title="Export to file">↓</button>
+                  <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: ws.id, name: ws.name })} title="Delete">×</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {tab === 'team' && (
+        <>
+          {sharedLoading && <p className="snippet-empty">Loading…</p>}
+          {!sharedLoading && shared.length === 0 && (
+            <p className="snippet-empty">No team workspaces yet.</p>
+          )}
+          <div className="snippet-list">
+            {shared.map((item) => (
+              <div key={item.id} className="snippet-item">
+                <span className="snippet-name" title={`${item.data.layout?.rows}×${item.data.layout?.cols}`}>{item.name}</span>
+                <div className="snippet-item-actions">
+                  <button className="snippet-send-btn" onClick={() => handleClone(item.data)} title="Clone to Mine">Clone</button>
+                  {item.owner_id === userId && (
+                    <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: item.id, name: item.name, shared: true })} title="Remove">×</button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {tab === 'templates' && (
+        <div className="snippet-list">
+          {TEMPLATES.map((tpl, i) => (
+            <div key={tpl.name} className="snippet-item" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
+              <div style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span className="snippet-name">{tpl.name}</span>
+                <button className="snippet-send-btn" onClick={() => handleUseTemplate(i)} title="Use this template">Use</button>
+              </div>
+              <span style={{ fontSize: 10, color: 'var(--text-muted)', paddingLeft: 2 }}>{tpl.description}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  )
+
+  const confirmDeleteDialog = confirmDelete ? (
+    <ConfirmDialog
+      title="Delete workspace"
+      message={`Delete "${confirmDelete.name}"?`}
+      confirmLabel="Delete"
+      confirmDanger
+      onConfirm={() => {
+        if (confirmDelete.shared) removeShared(confirmDelete.id)
+        else handleDelete(confirmDelete.id)
+        setConfirmDelete(null)
+      }}
+      onCancel={() => setConfirmDelete(null)}
+    />
+  ) : null
+
+  if (docked) {
+    return (
+      <>
+        <div className="snippet-panel workspace-panel workspace-panel--docked">{body}</div>
+        {confirmDeleteDialog}
+      </>
+    )
   }
 
   return (
@@ -198,122 +326,12 @@ export default function WorkspacePanel({ onSave, onLoad, onRequireUpgrade }: Pro
 
       {open && popPos && (
         <div ref={popoverRef} className="snippet-panel workspace-panel" style={{ position: 'fixed', top: popPos.top, left: popPos.left, right: 'auto' }}>
-          <div className="snippet-panel-header">
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button
-                className={`workspace-tab-btn${tab === 'mine' ? ' active' : ''}`}
-                onClick={() => setTab('mine')}
-              >Mine</button>
-              <button
-                className={`workspace-tab-btn${tab === 'team' ? ' active' : ''}`}
-                onClick={() => { setTab('team'); refreshShared() }}
-              >Team</button>
-              <button
-                className={`workspace-tab-btn${tab === 'templates' ? ' active' : ''}`}
-                onClick={() => setTab('templates')}
-              >Templates</button>
-            </div>
-            {tab === 'mine' && (
-              <div style={{ display: 'flex', gap: 4 }}>
-                <button className="snippet-add-btn" onClick={(e) => { e.stopPropagation(); handleImport() }} title="Import from file">↑</button>
-                <button className="snippet-add-btn" onClick={(e) => { e.stopPropagation(); setSaving((v) => !v) }} title="Save current workspace">+</button>
-              </div>
-            )}
-          </div>
-
-          {tab === 'mine' && (
-            <>
-              {saving && (
-                <div className="snippet-form">
-                  <input
-                    className="snippet-input"
-                    placeholder="Workspace name…"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    autoFocus
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') handleSave()
-                      if (e.key === 'Escape') setSaving(false)
-                    }}
-                  />
-                  <div className="snippet-form-actions">
-                    <button className="snippet-save-btn" onClick={handleSave}>Save</button>
-                    <button className="snippet-cancel-btn" onClick={() => setSaving(false)}>Cancel</button>
-                  </div>
-                </div>
-              )}
-              {workspaces.length === 0 && !saving && (
-                <p className="snippet-empty">No workspaces. Click + to save the current layout.</p>
-              )}
-              <div className="snippet-list">
-                {workspaces.map((ws) => (
-                  <div key={ws.id} className="snippet-item">
-                    <span className="snippet-name" title={`${ws.layout.rows}×${ws.layout.cols}`}>{ws.name}</span>
-                    <div className="snippet-item-actions">
-                      <button className="snippet-send-btn" onClick={() => handleLoad(ws)} title="Load">Load</button>
-                      <button className="snippet-send-btn" onClick={() => handleShare(ws)} title={team ? 'Share to Team' : 'Share to Community'}>↗</button>
-                      <button className="snippet-send-btn" onClick={() => handleExport(ws)} title="Export to file">↓</button>
-                      <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: ws.id, name: ws.name })} title="Delete">×</button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-
-          {tab === 'team' && (
-            <>
-              {sharedLoading && <p className="snippet-empty">Loading…</p>}
-              {!sharedLoading && shared.length === 0 && (
-                <p className="snippet-empty">No team workspaces yet.</p>
-              )}
-              <div className="snippet-list">
-                {shared.map((item) => (
-                  <div key={item.id} className="snippet-item">
-                    <span className="snippet-name" title={`${item.data.layout?.rows}×${item.data.layout?.cols}`}>{item.name}</span>
-                    <div className="snippet-item-actions">
-                      <button className="snippet-send-btn" onClick={() => handleClone(item.data)} title="Clone to Mine">Clone</button>
-                      {item.owner_id === userId && (
-                        <button className="snippet-delete-btn" onClick={() => setConfirmDelete({ id: item.id, name: item.name, shared: true })} title="Remove">×</button>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-
-          {tab === 'templates' && (
-            <div className="snippet-list">
-              {TEMPLATES.map((tpl, i) => (
-                <div key={tpl.name} className="snippet-item" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
-                  <div style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' }}>
-                    <span className="snippet-name">{tpl.name}</span>
-                    <button className="snippet-send-btn" onClick={() => handleUseTemplate(i)} title="Use this template">Use</button>
-                  </div>
-                  <span style={{ fontSize: 10, color: 'var(--text-muted)', paddingLeft: 2 }}>{tpl.description}</span>
-                </div>
-              ))}
-            </div>
-          )}
+          {body}
         </div>
       )}
     </div>
 
-    {confirmDelete && (
-      <ConfirmDialog
-        title="Delete workspace"
-        message={`Delete "${confirmDelete.name}"?`}
-        confirmLabel="Delete"
-        confirmDanger
-        onConfirm={() => {
-          if (confirmDelete.shared) removeShared(confirmDelete.id)
-          else handleDelete(confirmDelete.id)
-          setConfirmDelete(null)
-        }}
-        onCancel={() => setConfirmDelete(null)}
-      />
-    )}
+    {confirmDeleteDialog}
     </>
   )
 }

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import type { Plan } from '../lib/stripe'
+import { isE2EPreview } from '../lib/e2ePreview'
 
 const TRIAL_DAYS = 14
 
@@ -71,6 +72,12 @@ export function useProfile(): Profile {
     load()
     return () => { alive = false }
   }, [])
+
+  // LOCAL PREVIEW ONLY (gated on RAVEN_E2E bypass): unlock Pro/Team
+  // so My Repos / Teams render without a real Supabase backend.
+  if (isE2EPreview()) {
+    return { plan: 'team', loading: false, isTrialActive: false, trialDaysLeft: 0 }
+  }
 
   return profile
 }

--- a/src/hooks/useSharedMcpConfigs.ts
+++ b/src/hooks/useSharedMcpConfigs.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_MCP, FX_USER_ID } from '../lib/e2eFixtures'
 
 export interface SharedMcpConfig {
   id: string
@@ -62,6 +64,17 @@ export function useSharedMcpConfigs(teamId?: string) {
     }
     setItems(prev => prev.filter(i => i.id !== id))
   }, [])
+
+  if (isE2EPreview()) {
+    return {
+      items: FX_MCP as SharedMcpConfig[],
+      loading: false,
+      userId: FX_USER_ID,
+      refresh: async () => {},
+      share: async () => true,
+      remove: async () => {},
+    }
+  }
 
   return { items, loading, userId, refresh, share, remove }
 }

--- a/src/hooks/useSharedSnippets.ts
+++ b/src/hooks/useSharedSnippets.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_SNIPPETS, FX_USER_ID } from '../lib/e2eFixtures'
 
 export interface SharedSnippet {
   id: string
@@ -56,6 +58,17 @@ export function useSharedSnippets(teamId?: string) {
     }
     setItems(prev => prev.filter(i => i.id !== id))
   }, [])
+
+  if (isE2EPreview()) {
+    return {
+      items: FX_SNIPPETS as SharedSnippet[],
+      loading: false,
+      userId: FX_USER_ID,
+      refresh: async () => {},
+      share: async () => true,
+      remove: async () => {},
+    }
+  }
 
   return { items, loading, userId, refresh, share, remove }
 }

--- a/src/hooks/useSharedWorkspaces.ts
+++ b/src/hooks/useSharedWorkspaces.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
 import type { Workspace } from '../types'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_WORKSPACES, FX_USER_ID } from '../lib/e2eFixtures'
 
 export interface SharedWorkspace {
   id: string
@@ -62,6 +64,17 @@ export function useSharedWorkspaces(teamId?: string) {
     }
     setItems(prev => prev.filter(i => i.id !== id))
   }, [])
+
+  if (isE2EPreview()) {
+    return {
+      items: FX_WORKSPACES as unknown as SharedWorkspace[],
+      loading: false,
+      userId: FX_USER_ID,
+      refresh: async () => {},
+      share: async () => true,
+      remove: async () => {},
+    }
+  }
 
   return { items, loading, userId, refresh, share, remove }
 }

--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
-import { isE2EPreview } from '../lib/e2ePreview'
+import { isE2EPreview, isPreviewEmptyTeams } from '../lib/e2ePreview'
 import { FX_TEAM, FX_MEMBERS, FX_USER_ID } from '../lib/e2eFixtures'
 
 export interface Team {
@@ -394,12 +394,13 @@ export function useTeam() {
   }, [activeTeam, state.teams, state.userId, refresh])
 
   if (isE2EPreview()) {
+    const empty = isPreviewEmptyTeams()
     return {
-      teams: [FX_TEAM],
-      team: FX_TEAM,
-      activeTeam: FX_TEAM,
-      activeTeamId: FX_TEAM.id,
-      members: FX_MEMBERS,
+      teams: empty ? [] : [FX_TEAM],
+      team: empty ? null : FX_TEAM,
+      activeTeam: empty ? null : FX_TEAM,
+      activeTeamId: empty ? null : FX_TEAM.id,
+      members: empty ? [] : FX_MEMBERS,
       pendingInvites: [],
       myPendingRequests: [],
       loading: false,

--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_TEAM, FX_MEMBERS, FX_USER_ID } from '../lib/e2eFixtures'
 
 export interface Team {
   id: string
@@ -390,6 +392,36 @@ export function useTeam() {
     else localStorage.removeItem(storageKey(state.userId!))
     await refresh()
   }, [activeTeam, state.teams, state.userId, refresh])
+
+  if (isE2EPreview()) {
+    return {
+      teams: [FX_TEAM],
+      team: FX_TEAM,
+      activeTeam: FX_TEAM,
+      activeTeamId: FX_TEAM.id,
+      members: FX_MEMBERS,
+      pendingInvites: [],
+      myPendingRequests: [],
+      loading: false,
+      userId: FX_USER_ID,
+      userEmail: 'alex.k@acme.io',
+      switchTeam: async () => {},
+      refresh: async () => {},
+      createTeam: async () => ({ ok: true }),
+      inviteMember: async () => ({ ok: true }),
+      removeMember: async () => {},
+      promoteMember: async () => ({ ok: true }),
+      demoteMember: async () => ({ ok: true }),
+      acceptInvite: async () => ({ ok: true }),
+      rejectInvite: async () => {},
+      requestJoin: async () => ({ ok: true }),
+      cancelRequest: async () => ({ ok: true }),
+      approveRequest: async () => ({ ok: true }),
+      declineRequest: async () => ({ ok: true }),
+      leaveTeam: async () => {},
+      deleteTeam: async () => {},
+    }
+  }
 
   return {
     teams: state.teams,

--- a/src/hooks/useTeamChat.ts
+++ b/src/hooks/useTeamChat.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { supabase } from '../lib/supabase'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_CHAT } from '../lib/e2eFixtures'
 
 export interface ChatEvent {
   kind: 'event'
@@ -268,6 +270,19 @@ export function useTeamChat({ teamId, userId, userEmail, githubLogin, githubToke
       if (error) console.warn('[useTeamChat.toggleReaction] insert failed', { targetType, targetId, emoji }, error)
     }
   }, [teamId, userId, userEmail, reactions])
+
+  if (isE2EPreview()) {
+    return {
+      timeline: FX_CHAT,
+      reactions: [] as ChatReaction[],
+      loading: false,
+      error: null as string | null,
+      refresh: async () => {},
+      postMessage: async () => ({ ok: true }),
+      deleteMessage: async () => {},
+      toggleReaction: async () => {},
+    }
+  }
 
   // Combined timeline (newest first)
   const timeline: ChatItem[] = [...events, ...messages].sort(

--- a/src/hooks/useTeamPresence.ts
+++ b/src/hooks/useTeamPresence.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { RealtimeChannel } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_PRESENCE } from '../lib/e2eFixtures'
 
 export interface PresenceState {
   userId: string
@@ -69,6 +71,10 @@ export function useTeamPresence(teamId: string | null, currentUserId: string | n
       lastSeen: new Date().toISOString(),
     })
   }, [teamId, currentUserId])
+
+  if (isE2EPreview()) {
+    return { presence: FX_PRESENCE, updatePresence: async () => {} }
+  }
 
   return { presence, updatePresence }
 }

--- a/src/hooks/useTeamRepos.ts
+++ b/src/hooks/useTeamRepos.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react'
 import { supabase } from '../lib/supabase'
 import { PROVIDER_HOST } from '../components/ProviderAvatar'
+import { isE2EPreview } from '../lib/e2ePreview'
+import { FX_REPOS } from '../lib/e2eFixtures'
 
 export interface TeamRepo {
   id: string
@@ -151,6 +153,20 @@ export function useTeamRepos(teamId: string | null) {
       .upsert({ team_repo_id: repoId, user_id: userId, permission }, { onConflict: 'team_repo_id,user_id' })
     if (error) console.warn('[useTeamRepos.setPermission] upsert failed', { repoId, userId, permission }, error)
   }, [])
+
+  if (isE2EPreview()) {
+    return {
+      repos: FX_REPOS,
+      loading: false,
+      userLocalPaths: {} as Record<string, string>,
+      refresh: async () => {},
+      addRepo: async () => true,
+      updateUserLocalPath: async () => {},
+      updateLocalPath: async () => {},
+      removeRepo: async () => {},
+      setPermission: async () => {},
+    }
+  }
 
   return { repos, loading, userLocalPaths, refresh, addRepo, updateUserLocalPath, updateLocalPath, removeRepo, setPermission }
 }

--- a/src/hooks/useTeamsKeyboard.ts
+++ b/src/hooks/useTeamsKeyboard.ts
@@ -93,5 +93,5 @@ export function useTeamsKeyboard({ onClose, onSectionChange, currentSection }: T
       window.removeEventListener('keydown', handler)
       clearChordState()
     }
-  }, []) // sin dependencias: usamos refs para todo
+  }, []) // no dependencies: we use refs for everything
 }

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RAVEN Nest</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RAVEN Nest</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/e2eFixtures.ts
+++ b/src/lib/e2eFixtures.ts
@@ -1,0 +1,73 @@
+// src/lib/e2eFixtures.ts
+// Dev-only fixtures for the Teams preview harness. Imported ONLY from hooks behind
+// isE2EPreview(). Mirrors the acme-platform data from the nestmux TeamsDemo.
+import type { Team, TeamMember } from '../hooks/useTeam'
+import type { TeamRepo } from '../hooks/useTeamRepos'
+import type { PresenceState } from '../hooks/useTeamPresence'
+import type { ChatItem } from '../hooks/useTeamChat'
+
+export const FX_USER_ID = 'fx-user-alex'
+const T0 = '2026-06-01T12:00:00.000Z'
+
+export const FX_TEAM: Team = {
+  id: 'fx-team-acme',
+  name: 'acme-platform',
+  owner_id: FX_USER_ID,
+  created_at: T0,
+}
+
+export const FX_MEMBERS: TeamMember[] = [
+  { id: 'm-alex',   team_id: FX_TEAM.id, user_id: FX_USER_ID, email: 'alex.k@acme.io',   role: 'leader', status: 'active', invited_by: FX_USER_ID, invited_at: T0, accepted_at: T0 },
+  { id: 'm-sam',    team_id: FX_TEAM.id, user_id: 'u-sam',    email: 'sam.r@acme.io',    role: 'leader', status: 'active', invited_by: FX_USER_ID, invited_at: T0, accepted_at: T0 },
+  { id: 'm-devon',  team_id: FX_TEAM.id, user_id: 'u-devon',  email: 'devon.p@acme.io',  role: 'member', status: 'active', invited_by: FX_USER_ID, invited_at: T0, accepted_at: T0 },
+  { id: 'm-morgan', team_id: FX_TEAM.id, user_id: 'u-morgan', email: 'morgan.t@acme.io', role: 'member', status: 'active', invited_by: FX_USER_ID, invited_at: T0, accepted_at: T0 },
+  { id: 'm-riley',  team_id: FX_TEAM.id, user_id: 'u-riley',  email: 'riley.b@acme.io',  role: 'member', status: 'active', invited_by: FX_USER_ID, invited_at: T0, accepted_at: T0 },
+]
+
+const repo = (n: string, provider: 'github' | 'gitlab' = 'github'): TeamRepo => ({
+  id: `r-${n}`, team_id: FX_TEAM.id, repo_full_name: `acme/${n}`,
+  repo_url: `https://github.com/acme/${n}`, added_by: FX_USER_ID, added_at: T0,
+  local_path: null, provider,
+})
+export const FX_REPOS: TeamRepo[] = [
+  repo('platform-api'), repo('billing-service'), repo('auth-rewrite'),
+  repo('web-dashboard'), repo('payments-svc'), repo('data-pipeline'),
+]
+
+export const FX_PRESENCE: Record<string, PresenceState> = {
+  [FX_USER_ID]: { userId: FX_USER_ID, displayName: 'alex.k@acme.io', repo: 'acme/platform-api', branch: 'feat/auth-rewrite', lastSeen: T0 },
+  'u-sam':    { userId: 'u-sam',    displayName: 'sam.r@acme.io',    repo: 'acme/platform-api', branch: 'main',            lastSeen: T0 },
+  'u-devon':  { userId: 'u-devon',  displayName: 'devon.p@acme.io',  repo: 'acme/payments-svc', branch: 'fix/cache-key',  lastSeen: T0 },
+}
+
+export interface FxFeedEvent {
+  id: string; actor: string; avatar: string; action: string; detail: string | null
+  badge: 'push' | 'pr' | 'issue' | 'create'; repo: string; ago: string
+}
+export const FX_FEED: FxFeedEvent[] = [
+  { id: 'f1', actor: 'alex.k',   avatar: '', action: 'created branch "feat/auth-rewrite"', detail: null, badge: 'create', repo: 'acme/platform-api', ago: '6h' },
+  { id: 'f2', actor: 'sam.r',    avatar: '', action: 'opened PR #142',                     detail: 'add rate limiter v2', badge: 'pr', repo: 'acme/platform-api', ago: '3h' },
+  { id: 'f3', actor: 'devon.p',  avatar: '', action: 'created branch "fix/cache-key"',     detail: null, badge: 'create', repo: 'acme/payments-svc', ago: '1h' },
+  { id: 'f4', actor: 'morgan.t', avatar: '', action: 'pushed 3 commits',                   detail: 'wire standup digest', badge: 'push', repo: 'acme/auth-rewrite', ago: '12m' },
+  { id: 'f5', actor: 'riley.b',  avatar: '', action: 'opened issue #47',                   detail: 'Refresh token leaks on 401 retry', badge: 'issue', repo: 'acme/billing-service', ago: '1m' },
+]
+
+export const FX_SNIPPETS = [
+  { id: 's1', owner_id: FX_USER_ID, name: 'Staff review',   content: 'Review this diff with the eye of a staff engineer.', team_id: FX_TEAM.id, created_at: T0 },
+  { id: 's2', owner_id: FX_USER_ID, name: 'Write RFC',      content: 'Draft an RFC for: {{topic}}.', team_id: FX_TEAM.id, created_at: T0 },
+  { id: 's3', owner_id: 'u-sam',    name: 'Release notes',  content: 'Summarize commits since last tag.', team_id: FX_TEAM.id, created_at: T0 },
+]
+export const FX_WORKSPACES = [
+  { id: 'w1', owner_id: FX_USER_ID, name: 'auth-rewrite',     data: {}, team_id: FX_TEAM.id, created_at: T0 },
+  { id: 'w2', owner_id: 'u-devon',  name: 'payments-rollout', data: {}, team_id: FX_TEAM.id, created_at: T0 },
+]
+export const FX_MCP = [
+  { id: 'c1', owner_id: FX_USER_ID, name: 'github',   config: {}, team_id: FX_TEAM.id, created_at: T0 },
+  { id: 'c2', owner_id: 'u-sam',    name: 'postgres', config: {}, team_id: FX_TEAM.id, created_at: T0 },
+  { id: 'c3', owner_id: 'u-sam',    name: 'linear',   config: {}, team_id: FX_TEAM.id, created_at: T0 },
+]
+
+export const FX_CHAT: ChatItem[] = [
+  { kind: 'message', id: 'cm1', created_at: T0, user_id: FX_USER_ID, user_email: 'alex.k@acme.io', github_login: 'alex.k', content: 'anyone hitting flake on auth.spec.ts after the middleware refactor?' },
+  { kind: 'message', id: 'cm2', created_at: T0, user_id: 'u-sam', user_email: 'sam.r@acme.io', github_login: 'sam.r', content: 'yes - the cleanup hook is not awaiting. PR #142 patches it' },
+]

--- a/src/lib/e2ePreview.ts
+++ b/src/lib/e2ePreview.ts
@@ -1,0 +1,9 @@
+// src/lib/e2ePreview.ts
+// Dev-only preview gate. True only when the e2e/preview harness launched Electron
+// with RAVEN_E2E=1 (electron/preload.ts exposes window.appFlags.e2eBypass).
+// Production builds never set RAVEN_E2E, so this is always false for real users.
+export function isE2EPreview(): boolean {
+  return Boolean(
+    (window as unknown as { appFlags?: { e2eBypass?: boolean } }).appFlags?.e2eBypass
+  )
+}

--- a/src/lib/e2ePreview.ts
+++ b/src/lib/e2ePreview.ts
@@ -7,3 +7,11 @@ export function isE2EPreview(): boolean {
     (window as unknown as { appFlags?: { e2eBypass?: boolean } }).appFlags?.e2eBypass
   )
 }
+
+// Dev-only: when set, the Teams preview renders the "no team yet" welcome/join
+// state (teams: []) instead of the populated acme-platform fixture team.
+export function isPreviewEmptyTeams(): boolean {
+  return Boolean(
+    (window as unknown as { appFlags?: { previewEmptyTeams?: boolean } }).appFlags?.previewEmptyTeams
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import AuthScreen from './components/AuthScreen'
 import { supabase } from './lib/supabase'
+import '@fontsource-variable/inter'
+import '@fontsource-variable/geist-mono'
 import './styles/global.css'
 import '@xterm/xterm/css/xterm.css'
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,8 @@
   --font-ui: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Consolas, monospace;
 
+  --color-success: #22C55E;
+
   --titlebar-height: 44px;
   --header-height: 32px;
 }
@@ -91,7 +93,7 @@ body {
 
 .tabbar {
   height: var(--titlebar-height);
-  background: var(--bg-surface);
+  background: var(--bg-titlebar);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: flex-end;
@@ -165,16 +167,15 @@ body {
 .tab::before {
   content: '';
   position: absolute;
-  bottom: 0;
+  top: 0;
   left: 0;
   right: 0;
   height: 2px;
-  background: var(--tab-accent, var(--raven-blue));
-  opacity: 0.5;
+  background: var(--tab-accent, var(--accent));
+  opacity: 0;
   transition: opacity 0.15s;
 }
 
-.tab:hover::before,
 .tab.active::before {
   opacity: 1;
 }
@@ -187,7 +188,7 @@ body {
 
 .tab:not(.active):hover {
   color: var(--text-primary);
-  background: rgba(255,255,255,0.04);
+  background: var(--list-hover);
 }
 
 .tab-name {
@@ -1819,7 +1820,8 @@ body {
 
 .pane-header {
   height: var(--header-height);
-  background: color-mix(in srgb, var(--pane-color, var(--bg-surface)) 8%, var(--bg-surface));
+  background: var(--bg-pane);
+  border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1876,6 +1878,7 @@ body {
 .pane-ai-label {
   font-size: 11px;
   font-weight: 600;
+  font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.8px;
   flex-shrink: 0;
@@ -1883,7 +1886,7 @@ body {
 
 .pane-account-name {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--text-muted);
   flex-shrink: 0;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -399,12 +399,14 @@ body {
 }
 
 .sidebar-item:hover {
-  background: var(--bg-app);
+  background: var(--list-hover);
   color: var(--text-primary);
 }
 
 .sidebar-item.active {
-  color: #FFB800;
+  color: var(--accent);
+  background: var(--list-active);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 /* Plan badge on sidebar items */
@@ -537,8 +539,8 @@ body {
 }
 
 .sidebar-item.active:hover {
-  color: #FFB800;
-  background: #FFB80010;
+  color: var(--accent);
+  background: var(--list-active);
 }
 
 .sidebar-icon {
@@ -637,8 +639,8 @@ body {
 .settings-panel {
   position: absolute;
   width: 260px;
-  background: var(--bg-elevated, #1a1a1a);
-  border: 1px solid var(--border, #2a2a2a);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.4);
   z-index: 100;
@@ -688,8 +690,12 @@ body {
 }
 
 .sidebar-more-toggle {
-  color: var(--text-muted);
-  font-size: 12px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   height: 36px;
 }
 
@@ -709,7 +715,7 @@ body {
   overflow-x: hidden;
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
-  background: rgba(0,0,0,0.15);
+  background: var(--bg-elevated);
 }
 
 /* New Terminal — acción primaria al fondo del scroll. Tipografía ligeramente
@@ -720,7 +726,7 @@ body {
 }
 
 .sidebar-new-terminal:hover {
-  color: #0066FF;
+  color: var(--accent);
 }
 
 /* En modo colapsado (sin .expanded) la sidebar es de 44px y los labels van

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-﻿/* RAVEN Nest â€” Global Styles */
+/* RAVEN Nest â€” Global Styles */
 
 @keyframes spin {
   from { transform: rotate(0deg); }
@@ -80,6 +80,15 @@ body {
   background: var(--bg-app);
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
+}
+
+/* Global keyboard-focus ring — only on :focus-visible (keyboard nav), never on
+   mouse click. Components that suppress this with their own outline:none +
+   border/bg treatment still win by specificity; this fills the gap everywhere
+   else so keyboard users always see where they are. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* No-select on UI chrome only â€” never on terminal area */
@@ -193,6 +202,7 @@ body {
   user-select: none;
   position: relative;
   overflow: hidden;
+  transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
 }
 
 /* Active tab keeps a touch more breathing room when crowded */
@@ -460,7 +470,7 @@ body {
   letter-spacing: 0.5px;
   padding: 1px 5px;
   border-radius: 3px;
-  background: rgba(0,102,255,0.15);
+  background: oklch(0.72 0.17 156 / 0.15);
   color: var(--raven-blue);
   margin-left: auto;
   flex-shrink: 0;
@@ -476,11 +486,11 @@ body {
 }
 .sidebar-plan-indicator.free {
   color: var(--raven-blue) !important;
-  background: rgba(0,102,255,0.08) !important;
-  border-color: rgba(0,102,255,0.25);
+  background: oklch(0.72 0.17 156 / 0.08) !important;
+  border-color: oklch(0.72 0.17 156 / 0.25);
 }
 .sidebar-plan-indicator.free:hover {
-  background: rgba(0,102,255,0.15) !important;
+  background: oklch(0.72 0.17 156 / 0.15) !important;
 }
 
 .sidebar-updates {
@@ -818,7 +828,7 @@ body {
 
 .empty-cell:hover {
   border-color: var(--raven-blue);
-  background: #0066FF08;
+  background: oklch(0.72 0.17 156 / 0.031);
   color: var(--raven-blue);
 }
 
@@ -1014,7 +1024,7 @@ body {
   transition: background 0.1s;
 }
 .team-switcher-new:hover {
-  background: rgba(0, 102, 255, 0.08);
+  background: oklch(0.72 0.17 156 / 0.08);
 }
 
 /* Pending invite banner (inside team, for second invite) */
@@ -1100,7 +1110,7 @@ body {
   color: var(--text-primary);
 }
 .team-nav-btn.active {
-  background: #0066FF1a;
+  background: oklch(0.72 0.17 156 / 0.102);
   color: var(--raven-blue);
 }
 
@@ -1168,7 +1178,7 @@ body {
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: rgba(0, 102, 255, 0.13);
+  background: oklch(0.72 0.17 156 / 0.13);
   color: var(--raven-blue);
   font-size: 12px;
   font-weight: 600;
@@ -1249,9 +1259,9 @@ body {
 }
 
 .snippet-add-btn:hover {
-  background: #0066FF22;
+  background: oklch(0.72 0.17 156 / 0.133);
   color: var(--raven-blue);
-  border-color: #0066FF44;
+  border-color: oklch(0.72 0.17 156 / 0.267);
 }
 
 .snippet-form {
@@ -1276,7 +1286,7 @@ body {
 }
 
 .snippet-input:focus, .snippet-textarea:focus {
-  border-color: #0066FF66;
+  border-color: oklch(0.72 0.17 156 / 0.4);
 }
 
 .snippet-form-actions {
@@ -1309,12 +1319,12 @@ body {
   border-color: rgba(255, 255, 255, 0.14);
 }
 .snippet-save-btn:active:not(:disabled) {
-  background: #0052cc;
+  background: var(--accent-hover);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 .snippet-save-btn:focus-visible {
   outline: none;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 0 0 2px rgba(0, 102, 255, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 0 0 2px oklch(0.72 0.17 156 / 0.35);
 }
 .snippet-save-btn:disabled {
   opacity: 0.45;
@@ -1349,7 +1359,7 @@ body {
 .snippet-cancel-btn:focus-visible {
   outline: none;
   border-color: var(--raven-blue);
-  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.18);
+  box-shadow: 0 0 0 2px oklch(0.72 0.17 156 / 0.18);
 }
 
 .snippet-empty {
@@ -1413,9 +1423,9 @@ body {
 }
 
 .snippet-send-btn:hover {
-  background: #0066FF22;
+  background: oklch(0.72 0.17 156 / 0.133);
   color: var(--raven-blue);
-  border-color: #0066FF44;
+  border-color: oklch(0.72 0.17 156 / 0.267);
 }
 
 .snippet-broadcast-btn:hover {
@@ -1732,7 +1742,7 @@ body {
   font-size: 11px;
   font-family: inherit;
   background: #ffffff0a;
-  border: 1px solid #0066FF44;
+  border: 1px solid oklch(0.72 0.17 156 / 0.267);
   border-radius: 3px;
   color: var(--text-primary);
   padding: 1px 5px;
@@ -1830,7 +1840,7 @@ body {
 
 .layout-cell.active {
   border-color: var(--raven-blue);
-  background: #0066FF22;
+  background: oklch(0.72 0.17 156 / 0.133);
 }
 
 .layout-cell:hover {
@@ -1988,8 +1998,8 @@ body {
   font-family: var(--font-mono);
   letter-spacing: 0.4px;
   color: var(--raven-blue);
-  background: #0066FF15;
-  border: 1px solid #0066FF30;
+  background: oklch(0.72 0.17 156 / 0.082);
+  border: 1px solid oklch(0.72 0.17 156 / 0.188);
   border-radius: 3px;
   padding: 1px 5px;
   flex-shrink: 0;
@@ -2001,7 +2011,7 @@ body {
   align-items: center;
   gap: 4px;
   background: transparent;
-  border: 1px solid #0066FF44;
+  border: 1px solid oklch(0.72 0.17 156 / 0.267);
   color: var(--raven-blue);
   font-size: 11px;
   font-weight: 500;
@@ -2014,8 +2024,8 @@ body {
 }
 
 .pane-restart-btn:hover {
-  background: #0066FF22;
-  border-color: #0066FF88;
+  background: oklch(0.72 0.17 156 / 0.133);
+  border-color: oklch(0.72 0.17 156 / 0.533);
 }
 
 /* Sync cwd button â€” live pane cwd diverges from active repo */
@@ -2059,7 +2069,7 @@ body {
 }
 
 .pane-zoom-btn:hover {
-  background: #0066FF22;
+  background: oklch(0.72 0.17 156 / 0.133);
   color: var(--raven-blue);
 }
 
@@ -2394,11 +2404,11 @@ body {
 }
 
 .file-staging-input:focus {
-  border-color: #0066FF;
+  border-color: var(--accent);
 }
 
 .file-staging-send {
-  background: #0066FF;
+  background: var(--accent);
   border: none;
   border-radius: 4px;
   color: #fff;
@@ -3422,7 +3432,7 @@ body {
 }
 
 .block-expand-btn:hover {
-  background: #0066FF0a;
+  background: oklch(0.72 0.17 156 / 0.039);
 }
 
 .pane-blocks-btn {
@@ -3549,8 +3559,8 @@ body {
   width: 48px;
   height: 48px;
   border-radius: 12px;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.18) 0%, rgba(0, 102, 255, 0.04) 100%);
-  border: 1px solid rgba(0, 102, 255, 0.3);
+  background: linear-gradient(135deg, oklch(0.72 0.17 156 / 0.18) 0%, oklch(0.72 0.17 156 / 0.04) 100%);
+  border: 1px solid oklch(0.72 0.17 156 / 0.3);
   color: var(--raven-blue);
   display: flex;
   align-items: center;
@@ -3593,9 +3603,9 @@ body {
 }
 
 .upgrade-plan.popular {
-  border-color: rgba(0, 102, 255, 0.45);
-  background: linear-gradient(180deg, rgba(0, 102, 255, 0.06) 0%, var(--bg-surface) 80%);
-  box-shadow: 0 0 0 1px rgba(0, 102, 255, 0.1) inset;
+  border-color: oklch(0.72 0.17 156 / 0.45);
+  background: linear-gradient(180deg, oklch(0.72 0.17 156 / 0.06) 0%, var(--bg-surface) 80%);
+  box-shadow: 0 0 0 1px oklch(0.72 0.17 156 / 0.1) inset;
 }
 
 .upgrade-plan.current {
@@ -3616,7 +3626,7 @@ body {
   padding: 3px 9px;
   border-radius: 999px;
   white-space: nowrap;
-  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.35);
+  box-shadow: 0 4px 12px oklch(0.72 0.17 156 / 0.35);
 }
 
 .upgrade-plan-head {
@@ -4526,7 +4536,7 @@ kbd {
 
 .global-search-result-item:hover,
 .global-search-result-item.selected {
-  background: #0066FF18;
+  background: oklch(0.72 0.17 156 / 0.094);
 }
 
 .global-search-result-label {
@@ -4645,12 +4655,16 @@ kbd {
   gap: 10px;
   padding: 7px 16px;
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--dur-fast) var(--ease);
 }
 
-.cmd-item:hover,
+.cmd-item:hover {
+  background: var(--list-hover);
+}
+
 .cmd-item.selected {
-  background: rgba(0, 102, 255, 0.12);
+  background: oklch(0.72 0.17 156 / 0.13);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .cmd-item-label {
@@ -4961,7 +4975,7 @@ kbd {
 }
 
 .upgrade-save-badge {
-  background: #0066FF22;
+  background: oklch(0.72 0.17 156 / 0.133);
   color: var(--raven-blue);
   font-size: 10px;
   font-weight: 600;
@@ -5115,7 +5129,7 @@ kbd {
 }
 
 .tw-nav-btn.active {
-  background: #0066FF1a;
+  background: oklch(0.72 0.17 156 / 0.102);
   color: var(--raven-blue);
 }
 
@@ -5354,10 +5368,10 @@ kbd {
   background: var(--bg-surface);
 }
 .notification-item--unread {
-  background: #0066FF08;
+  background: oklch(0.72 0.17 156 / 0.031);
 }
 .notification-item--unread:hover {
-  background: #0066FF14;
+  background: oklch(0.72 0.17 156 / 0.078);
 }
 
 .notification-type-icon {
@@ -5826,8 +5840,8 @@ button.ci-badge:hover {
   color: #fff;
 }
 .repo-picker-action-btn.primary:hover:not(:disabled) {
-  background: #0052cc;
-  border-color: #0052cc;
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
 /* â”€â”€ Repo actions overflow menu (â‹¯) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
@@ -5941,7 +5955,7 @@ button.ci-badge:hover {
 .repo-action-btn:focus-visible {
   outline: none;
   border-color: var(--raven-blue);
-  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.18);
+  box-shadow: 0 0 0 2px oklch(0.72 0.17 156 / 0.18);
 }
 .repo-action-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
@@ -5958,18 +5972,18 @@ button.ci-badge:hover {
   color: #fff;
 }
 .repo-action-btn.primary:active {
-  background: #0052cc;
+  background: var(--accent-hover);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 .repo-action-btn.primary .ra-icon { opacity: 1; }
 
 .repo-action-btn.subtle-accent {
-  border-color: rgba(0, 102, 255, 0.28);
+  border-color: oklch(0.72 0.17 156 / 0.28);
   color: #6ea6ff;
 }
 .repo-action-btn.subtle-accent:hover {
-  background: rgba(0, 102, 255, 0.08);
-  border-color: rgba(0, 102, 255, 0.5);
+  background: oklch(0.72 0.17 156 / 0.08);
+  border-color: oklch(0.72 0.17 156 / 0.5);
   color: #8fbcff;
 }
 
@@ -6015,7 +6029,7 @@ button.ci-badge:hover {
 .tw-provider-avatar:hover {
   border-color: var(--raven-blue);
   transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 102, 255, 0.25);
+  box-shadow: 0 2px 8px oklch(0.72 0.17 156 / 0.25);
   z-index: 2;
 }
 .tw-provider-avatar img {
@@ -6226,8 +6240,8 @@ button.ci-badge:hover {
   border-color: rgba(255,255,255,0.22);
 }
 .chat-reaction.mine {
-  background: rgba(0, 102, 255, 0.14);
-  border-color: rgba(0, 102, 255, 0.4);
+  background: oklch(0.72 0.17 156 / 0.14);
+  border-color: oklch(0.72 0.17 156 / 0.4);
 }
 
 .chat-reaction-count {
@@ -6312,7 +6326,7 @@ button.ci-badge:hover {
 }
 .chat-composer-input:focus {
   border-color: var(--raven-blue);
-  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.18);
+  box-shadow: 0 0 0 3px oklch(0.72 0.17 156 / 0.18);
 }
 
 .chat-composer-send {
@@ -6326,7 +6340,7 @@ button.ci-badge:hover {
   cursor: pointer;
   transition: background 0.15s;
 }
-.chat-composer-send:hover:not(:disabled) { background: #0052cc; }
+.chat-composer-send:hover:not(:disabled) { background: var(--accent-hover); }
 .chat-composer-send:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .chat-composer-error {
@@ -6606,7 +6620,7 @@ button.ci-badge:hover {
   cursor: pointer;
   outline: none;
 }
-.sp-select:focus { border-color: #0066FF66; }
+.sp-select:focus { border-color: oklch(0.72 0.17 156 / 0.4); }
 
 .sp-divider {
   height: 1px;
@@ -6963,7 +6977,7 @@ button.ci-badge:hover {
   color: #fff;
 }
 .user-menu-popover-badge.user-menu-dot--free  { background: #444; color: #ccc; }
-.user-menu-popover-badge.user-menu-dot--pro   { background: rgba(0,102,255,0.2); color: var(--raven-blue); }
+.user-menu-popover-badge.user-menu-dot--pro   { background: oklch(0.72 0.17 156 / 0.2); color: var(--raven-blue); }
 .user-menu-popover-badge.user-menu-dot--team  { background: rgba(255,184,0,0.18); color: #FFB800; }
 .user-menu-popover-badge.user-menu-dot--trial { background: rgba(255,184,0,0.18); color: #FFB800; }
 
@@ -7119,7 +7133,7 @@ button.ci-badge:hover {
 }
 .actions-row:focus-visible {
   background: var(--bg-app, #050505);
-  box-shadow: 0 0 0 1px var(--raven-blue, #0066FF);
+  box-shadow: 0 0 0 1px var(--raven-blue, var(--accent));
 }
 .actions-row--empty,
 .actions-row--error {
@@ -7225,11 +7239,11 @@ button.ci-badge:hover {
 }
 .actions-bar:hover {
   background: var(--bg-app, #050505);
-  border-color: var(--raven-blue, #0066FF);
+  border-color: var(--raven-blue, var(--accent));
 }
 .actions-bar:focus-visible {
-  border-color: var(--raven-blue, #0066FF);
-  box-shadow: 0 0 0 1px var(--raven-blue, #0066FF);
+  border-color: var(--raven-blue, var(--accent));
+  box-shadow: 0 0 0 1px var(--raven-blue, var(--accent));
 }
 .actions-bar--muted,
 .actions-bar--error {
@@ -7489,7 +7503,7 @@ button.ci-badge:hover {
   background: transparent; border: none; color: var(--text-primary);
   padding: 6px 12px; font-size: 12px; cursor: pointer;
 }
-.wt-ctx-item:hover { background: rgba(0, 102, 255, 0.10); }
+.wt-ctx-item:hover { background: oklch(0.72 0.17 156 / 0.10); }
 .wt-ctx-item:disabled { color: var(--text-muted); cursor: not-allowed; }
 
 /* === Preset cards in NewWorktreeModal (Plan 2) === */
@@ -7506,7 +7520,7 @@ button.ci-badge:hover {
 }
 .preset-card:hover:not(:disabled) { border-color: var(--text-muted); }
 .preset-card:disabled { opacity: 0.5; cursor: not-allowed; }
-.preset-card-selected { border-color: var(--raven-blue); background: rgba(0, 102, 255, 0.08); }
+.preset-card-selected { border-color: var(--raven-blue); background: oklch(0.72 0.17 156 / 0.08); }
 .preset-card-name { font-size: 12px; font-weight: 600; }
 .preset-card-desc {
   font-size: 11px; color: var(--text-secondary);
@@ -7581,7 +7595,7 @@ button.ci-badge:hover {
   font-size: 11px; cursor: pointer; transition: background 0.12s, border-color 0.12s;
 }
 .port-pill:hover {
-  background: rgba(0, 102, 255, 0.12); border-color: var(--raven-blue);
+  background: oklch(0.72 0.17 156 / 0.12); border-color: var(--raven-blue);
 }
 .port-pill-discovered {
   border-style: dashed;
@@ -7767,7 +7781,7 @@ button.ci-badge:hover {
   width: 100%; background: transparent; border: none; cursor: pointer;
   padding: 6px 12px; color: var(--text-primary); text-align: left;
 }
-.ide-picker-item:hover { background: rgba(0, 102, 255, 0.10); }
+.ide-picker-item:hover { background: oklch(0.72 0.17 156 / 0.10); }
 .ide-picker-name { font-size: 12px; font-weight: 500; }
 .ide-picker-path { font-size: 10px; color: var(--text-muted); font-family: var(--font-mono); }
 .ide-picker-divider { height: 1px; background: var(--border); margin: 4px 0; }
@@ -7814,26 +7828,26 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .resource-bar-pill:hover {
   color: var(--text-primary);
-  border-color: rgba(0, 102, 255, 0.4);
-  background: rgba(0, 102, 255, 0.06);
+  border-color: oklch(0.72 0.17 156 / 0.4);
+  background: oklch(0.72 0.17 156 / 0.06);
 }
 
 .resource-bar-pill--open {
   color: var(--text-primary);
   border-color: var(--raven-blue);
-  background: rgba(0, 102, 255, 0.1);
+  background: oklch(0.72 0.17 156 / 0.1);
 }
 
 .resource-bar-pill:hover {
   color: var(--text-primary);
-  border-color: rgba(0, 102, 255, 0.4);
-  background: rgba(0, 102, 255, 0.08);
+  border-color: oklch(0.72 0.17 156 / 0.4);
+  background: oklch(0.72 0.17 156 / 0.08);
 }
 
 .resource-bar-pill--open {
   color: var(--text-primary);
   border-color: var(--raven-blue);
-  background: rgba(0, 102, 255, 0.12);
+  background: oklch(0.72 0.17 156 / 0.12);
 }
 
 .rb-overlay {
@@ -8073,8 +8087,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
   width: 48px;
   height: 48px;
   border-radius: 12px;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.18) 0%, rgba(0, 102, 255, 0.04) 100%);
-  border: 1px solid rgba(0, 102, 255, 0.3);
+  background: linear-gradient(135deg, oklch(0.72 0.17 156 / 0.18) 0%, oklch(0.72 0.17 156 / 0.04) 100%);
+  border: 1px solid oklch(0.72 0.17 156 / 0.3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8226,8 +8240,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  background: linear-gradient(135deg, rgba(0, 102, 255, 0.08) 0%, rgba(0, 102, 255, 0.02) 100%);
-  border: 1px solid rgba(0, 102, 255, 0.22);
+  background: linear-gradient(135deg, oklch(0.72 0.17 156 / 0.08) 0%, oklch(0.72 0.17 156 / 0.02) 100%);
+  border: 1px solid oklch(0.72 0.17 156 / 0.22);
   border-radius: 10px;
   padding: 12px 14px;
 }
@@ -8415,13 +8429,13 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .browser-port-item:focus-visible {
-  background: rgba(0, 102, 255, 0.14);
-  outline: 1px solid rgba(0, 102, 255, 0.5);
+  background: oklch(0.72 0.17 156 / 0.14);
+  outline: 1px solid oklch(0.72 0.17 156 / 0.5);
   outline-offset: -1px;
 }
 
 .browser-port-item:active {
-  background: rgba(0, 102, 255, 0.2);
+  background: oklch(0.72 0.17 156 / 0.2);
   transform: scale(0.99);
 }
 
@@ -8491,7 +8505,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: inline-block;
   padding: 1px 5px;
   border-radius: 4px;
-  background: rgba(0, 102, 255, 0.12);
+  background: oklch(0.72 0.17 156 / 0.12);
   color: var(--raven-blue);
   font-family: var(--font-mono);
   font-size: 10px;
@@ -8767,7 +8781,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .tjcp-icon-btn:focus-visible {
   outline: none;
   border-color: var(--raven-blue);
-  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.25);
+  box-shadow: 0 0 0 2px oklch(0.72 0.17 156 / 0.25);
 }
 .tjcp-icon-btn:disabled {
   opacity: 0.4;
@@ -8814,7 +8828,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 .tjcp-primary-btn:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.35);
+  box-shadow: 0 0 0 2px oklch(0.72 0.17 156 / 0.35);
 }
 .tjcp-primary-btn:disabled {
   opacity: 0.5;
@@ -8873,9 +8887,9 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .jcf-input:focus {
-  border-color: var(--raven-blue, #0066FF);
+  border-color: var(--raven-blue, var(--accent));
   background: #0d0d0d;
-  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.16);
+  box-shadow: 0 0 0 3px oklch(0.72 0.17 156 / 0.16);
 }
 
 .jcf-input:disabled {
@@ -8890,8 +8904,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 8px;
   width: 100%;
   padding: 11px 14px;
-  background: var(--raven-blue, #0066FF);
-  border: 1px solid var(--raven-blue, #0066FF);
+  background: var(--raven-blue, var(--accent));
+  border: 1px solid var(--raven-blue, var(--accent));
   border-radius: 9px;
   color: #fff;
   font-family: inherit;
@@ -8913,7 +8927,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .jcf-submit-btn:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.35);
+  box-shadow: 0 0 0 3px oklch(0.72 0.17 156 / 0.35);
 }
 
 .jcf-submit-btn:disabled {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9103,4 +9103,5 @@ n.nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-righ
 .nav-content{flex:1;min-height:0;overflow-y:auto;margin-top:6px;border-top:1px solid var(--border);padding-top:4px}
 .nav-content::-webkit-scrollbar{width:10px}
 .nav-content::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}
+.nav-spacer{flex:1;min-height:8px}
 .nav-footer{flex-shrink:0;border-top:1px solid var(--border);margin-top:6px;padding:4px 8px 0;display:flex;flex-direction:column;gap:1px}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,6 +16,7 @@
   --bg-sidebar: #252526;
   --bg-elevated: #2d2d30;   /* popovers, modals */
   --bg-titlebar: #323233;
+  --bg-activity: #2d2d30;
   --bg-pane: #181818;       /* terminal cell background */
 
   --border: #2b2b2b;        /* subtle border */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,11 @@
 
   --color-success: #22C55E;
 
+  /* Back-compat aliases for stray token references */
+  --bg-primary: var(--bg-app);
+  --bg-secondary: var(--bg-surface);
+  --bg-hover: var(--list-hover);
+
   --titlebar-height: 44px;
   --header-height: 32px;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,17 @@
 
   --titlebar-height: 44px;
   --header-height: 32px;
+
+  /* Motion — one easing + two durations so interactions feel intentional,
+     not snappy/default. Used across nav, buttons, popovers. */
+  --ease: cubic-bezier(0.2, 0, 0, 1);
+  --dur-fast: 0.12s;
+  --dur: 0.16s;
+}
+
+@keyframes popover-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: none; }
 }
 
 * {
@@ -847,10 +858,11 @@ body {
   max-height: 70vh;
   overflow-y: auto;
   background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   border-radius: 10px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 10px 34px rgba(0, 0, 0, 0.55), 0 0 0 1px oklch(1 0 0 / 0.02);
   z-index: 300;
+  animation: popover-in var(--dur) var(--ease);
 }
 
 /* â”€â”€ Team Modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
@@ -4029,26 +4041,28 @@ body {
   align-items: center;
   justify-content: center;
   height: 100%;
-  gap: 12px;
+  gap: 10px;
   color: var(--text-secondary);
 }
 
 .empty-logo {
-  margin-top: 40px;
+  margin-top: 28px;
+  margin-bottom: 6px;
 }
 
 .empty-logo-img {
-  width: 260px;
-  height: 260px;
+  width: 232px;
+  height: 232px;
   object-fit: contain;
   display: block;
 }
 
 .empty-title {
-  font-size: 30px;
+  font-size: 33px;
   font-weight: 600;
   color: var(--text-primary);
-  letter-spacing: -0.022em;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
 }
 
 .empty-title .raven {
@@ -4058,7 +4072,7 @@ body {
 .empty-subtitle {
   font-size: 14px;
   color: var(--text-muted);
-  margin-bottom: 8px;
+  margin-bottom: 14px;
 }
 
 .empty-hint {
@@ -4078,19 +4092,23 @@ kbd {
 /* â”€â”€ Buttons â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .btn-primary {
-  background: var(--raven-blue);
-  color: #fff;
+  background: var(--accent);
+  color: #04130c;
   border: none;
   border-radius: 8px;
   padding: 10px 24px;
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease);
 }
 
 .btn-primary:hover {
-  background: #0052cc;
+  background: var(--accent-hover);
+}
+
+.btn-primary:active {
+  transform: translateY(1px);
 }
 
 .btn-primary:disabled {
@@ -9106,12 +9124,11 @@ body.platform-mac .tabbar { padding-right: 116px; }
   background: transparent;
 }
 .tabbar-tool svg{width:17px;height:17px}
-n.nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0;padding:6px 0}n.nav-item{display:flex;align-items:center;gap:11px;height:34px;padding:0 11px;border-radius:7px;color:var(--text-secondary);font-size:13px;font-family:var(--font-ui);background:none;border:none;cursor:pointer;width:100%;text-align:left;position:relative}n.nav-item:hover{background:var(--list-hover);color:var(--text-primary)}n.nav-item.active{background:oklch(0.72 0.17 156 / 0.13);color:oklch(0.85 0.13 156);font-weight:500}n.nav-item-label{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}n.nav-item-primary{color:oklch(0.82 0.14 156)}n.nav-content{flex:1;min-height:0;overflow-y:auto;margin-top:6px;border-top:1px solid var(--border);padding-top:4px}n.nav-content::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}n
 /* ── Labeled nav sidebar (Teams-style) ─────────────────────────────────── */
 .nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0;padding:6px 0}
 .nav-group{display:flex;flex-direction:column;flex-shrink:0;padding:0 8px;gap:1px}
-.nav-item{display:flex;align-items:center;gap:11px;height:34px;padding:0 11px;border-radius:7px;color:var(--text-secondary);font-size:13px;font-family:var(--font-ui);background:none;border:none;cursor:pointer;width:100%;text-align:left;position:relative}
-.nav-item svg{width:17px;height:17px;color:var(--text-muted);flex-shrink:0;stroke-width:1.7}
+.nav-item{display:flex;align-items:center;gap:11px;height:34px;padding:0 11px;border-radius:8px;color:var(--text-secondary);font-size:13px;font-family:var(--font-ui);background:none;border:none;cursor:pointer;width:100%;text-align:left;position:relative;transition:background var(--dur-fast) var(--ease),color var(--dur-fast) var(--ease)}
+.nav-item svg{width:17px;height:17px;color:var(--text-muted);flex-shrink:0;stroke-width:1.7;transition:color var(--dur-fast) var(--ease)}
 .nav-item:hover{background:var(--list-hover);color:var(--text-primary)}
 .nav-item:hover svg{color:var(--text-secondary)}
 .nav-item.active{background:oklch(0.72 0.17 156 / 0.13);color:oklch(0.85 0.13 156);font-weight:500}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8005,6 +8005,10 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .rb-bullet-logo {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
 /* â”€â”€ Empty state: Join / Create tabs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .empty-state-wrap {
@@ -8593,6 +8597,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-variant-numeric: tabular-nums;
 }
 
+.team-switcher-item-icon {
   flex-shrink: 0;
   color: var(--text-muted);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9116,6 +9116,11 @@ n.nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-righ
 .nav-item-badge{margin-left:auto;background:var(--accent);color:#04130c;font-size:10px;font-weight:700;min-width:16px;height:16px;border-radius:8px;display:flex;align-items:center;justify-content:center;padding:0 4px}
 .nav-item-primary{color:oklch(0.82 0.14 156)}
 .nav-item-primary svg{color:oklch(0.80 0.15 156)}
+/* Worktrees inline accordion body — bounded + scrollable so a long worktree
+   list never pushes the rest of the nav items off-screen. */
+.nav-accordion-body{max-height:42vh;overflow-y:auto;overflow-x:hidden;margin:1px 0 3px}
+.nav-accordion-body::-webkit-scrollbar{width:10px}
+.nav-accordion-body::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}
 .nav-content{flex:1;min-height:0;overflow-y:auto;margin-top:6px;border-top:1px solid var(--border);padding-top:4px}
 .nav-content::-webkit-scrollbar{width:10px}
 .nav-content::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -875,6 +875,41 @@ body {
   animation: popover-in var(--dur) var(--ease);
 }
 
+/* ── Session panel (tokens / MCP / git / broadcast) ─────────────────────── */
+.session-panel{padding:12px 13px;font-family:var(--font-ui)}
+.session-head{display:flex;align-items:center;gap:8px;margin-bottom:11px}
+.session-title{font-size:13px;font-weight:600;color:var(--text-primary)}
+.session-live{display:flex;align-items:center;gap:5px;font-family:var(--font-mono);font-size:10px;color:var(--accent)}
+.session-live-dot{width:6px;height:6px;border-radius:50%;background:var(--accent);box-shadow:0 0 7px var(--accent);animation:pulse-dot 1.6s infinite}
+@keyframes pulse-dot{50%{opacity:.4}}
+.session-uptime{margin-left:auto;font-family:var(--font-mono);font-size:10px;color:var(--text-muted)}
+.session-metrics{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--border-subtle);border:1px solid var(--border-subtle);border-radius:9px;overflow:hidden;margin-bottom:12px}
+.session-metric{background:var(--bg-elevated);padding:9px 11px;display:flex;flex-direction:column;gap:3px}
+.session-metric-label{font-family:var(--font-mono);font-size:8.5px;letter-spacing:.08em;color:var(--text-muted)}
+.session-metric-value{font-family:var(--font-mono);font-size:18px;font-weight:700;color:var(--text-primary);line-height:1;letter-spacing:-.02em}
+.session-metric-value small{font-size:11px;color:var(--text-secondary);font-weight:500}
+.session-metric-delta{font-family:var(--font-mono);font-size:9.5px}
+.session-metric-delta.up{color:var(--accent)}
+.session-metric-delta.flat{color:var(--text-muted)}
+.session-metric-delta.warn{color:oklch(0.8 0.13 75)}
+.session-spark-head{font-family:var(--font-mono);font-size:8.5px;letter-spacing:.08em;color:var(--text-muted);margin-bottom:5px}
+.session-spark{display:flex;align-items:flex-end;gap:2px;height:38px;margin-bottom:13px}
+.session-spark i{flex:1;border-radius:1px;background:linear-gradient(to top, oklch(0.72 0.17 156 / 0.45), var(--accent));min-height:2px}
+.session-tabs{display:flex;gap:3px;margin-bottom:9px}
+.session-tab{flex:1;font-family:var(--font-mono);font-size:10px;padding:5px 0;border-radius:6px;border:1px solid var(--border-subtle);background:transparent;color:var(--text-secondary);cursor:pointer;transition:background var(--dur-fast) var(--ease),color var(--dur-fast) var(--ease)}
+.session-tab:hover{color:var(--text-primary);background:var(--list-hover)}
+.session-tab.active{color:var(--accent);border-color:oklch(0.72 0.17 156 / 0.4);background:oklch(0.72 0.17 156 / 0.1)}
+.session-list{display:flex;flex-direction:column;gap:1px}
+.session-row{display:flex;align-items:center;gap:8px;height:28px;padding:0 8px;border-radius:6px;font-family:var(--font-mono);font-size:11px;color:var(--text-secondary)}
+.session-row:hover{background:var(--list-hover)}
+.session-pip{width:6px;height:6px;border-radius:50%;flex-shrink:0}
+.session-pip.ok{background:var(--accent);box-shadow:0 0 6px var(--accent)}
+.session-pip.slow{background:oklch(0.8 0.13 75);box-shadow:0 0 6px oklch(0.8 0.13 75)}
+.session-pip.idle{background:var(--text-muted)}
+.session-row-name{flex:1;color:var(--text-primary);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.session-row-meta{font-size:9.5px;color:var(--text-muted)}
+.session-row-val{font-size:10px;color:var(--text-secondary);min-width:50px;text-align:right}
+
 /* â”€â”€ Team Modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-modal-overlay {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,28 +6,32 @@
 }
 
 :root {
-  --raven-blue: #0066FF;
-  --raven-blue-dim: #0066FF44;
-  --accent: var(--raven-blue);
+  /* Brand accent — emerald + cyan (matches nestmux.com demo).
+     Legacy name --raven-blue kept so existing var(--raven-blue) usages follow. */
+  --accent: oklch(0.72 0.17 156);
+  --accent-hover: oklch(0.66 0.18 156);
+  --accent-cyan: oklch(0.80 0.13 195);
+  --raven-blue: var(--accent);
+  --raven-blue-dim: oklch(0.72 0.17 156 / 0.28);
 
-  /* Carbon layered surfaces (VS Code-style) */
-  --bg-app: #1e1e1e;        /* base / editor */
-  --bg-surface: #252526;    /* sidebar, panels, tabs */
-  --bg-sidebar: #252526;
-  --bg-elevated: #2d2d30;   /* popovers, modals */
-  --bg-titlebar: #323233;
-  --bg-activity: #2d2d30;
-  --bg-pane: #181818;       /* terminal cell background */
+  /* Near-black layered surfaces (matches demo) */
+  --bg-app: oklch(0.155 0.004 240);      /* base behind panes */
+  --bg-surface: oklch(0.185 0.005 240);  /* sidebar, panels, tabs */
+  --bg-sidebar: oklch(0.175 0.005 240);
+  --bg-elevated: oklch(0.215 0.006 240); /* popovers, modals */
+  --bg-titlebar: oklch(0.205 0.005 240);
+  --bg-activity: oklch(0.165 0.005 240);
+  --bg-pane: #000000;                     /* terminal cells — black like the demo */
 
-  --border: #2b2b2b;        /* subtle border */
-  --border-strong: #333333; /* visible border */
+  --border: oklch(1 0 0 / 0.07);         /* subtle border */
+  --border-strong: oklch(1 0 0 / 0.14);  /* visible border */
 
-  --text-primary: #d4d4d4;
-  --text-secondary: #969696;
-  --text-muted: #6a6a6a;
+  --text-primary: oklch(0.95 0 0);
+  --text-secondary: oklch(0.66 0 0);
+  --text-muted: oklch(0.48 0 0);
 
-  --list-hover: #2a2d2e;
-  --list-active: #37373d;
+  --list-hover: oklch(1 0 0 / 0.05);
+  --list-active: oklch(1 0 0 / 0.09);
 
   /* Typography */
   --font-ui: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -101,13 +105,15 @@ body {
   align-items: center;
   gap: 14px;
   padding: 0 11px;
-  background: var(--accent);
-  color: #fff;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
   font-family: var(--font-ui);
   font-size: 11px;
   user-select: none;
   -webkit-user-select: none;
 }
+.status-bar .status-item:first-child { color: var(--text-primary); }
 .status-item-end { margin-left: auto; }
 
 
@@ -9045,13 +9051,13 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .repo-card-ext:hover{background:var(--list-hover);color:var(--text-primary)}
 .repo-card-ext svg{width:13px;height:13px}
 .repo-card-meta{display:flex;align-items:center;gap:8px;margin-top:7px}
-.branch-pill{display:inline-flex;align-items:center;gap:5px;font-family:var(--font-mono);font-size:11px;color:#cdd6f4;background:#0066ff1f;border:1px solid #0066ff33;padding:2px 8px;border-radius:11px}
+.branch-pill{display:inline-flex;align-items:center;gap:5px;font-family:var(--font-mono);font-size:11px;color:oklch(0.86 0.09 156);background:oklch(0.72 0.17 156 / 0.13);border:1px solid oklch(0.72 0.17 156 / 0.25);padding:2px 8px;border-radius:11px}
 .branch-pill svg{width:11px;height:11px}
 .branch-pill.dirty{color:#f0c674;background:#f59e0b1a;border-color:#f59e0b33}
 .repo-sync{font-size:11px;color:var(--text-muted);display:flex;align-items:center;gap:4px}
 .repo-sync svg{width:11px;height:11px}
 .side-panel-link{margin:2px 8px 8px;display:flex;align-items:center;gap:7px;padding:9px 10px;border:1px dashed var(--border-strong);border-radius:7px;color:var(--text-secondary);font-size:13px;background:none;cursor:pointer;width:calc(100% - 16px)}
-.side-panel-link:hover{border-color:#0066ff66;color:#cdd6f4;background:#0066ff0d}
+.side-panel-link:hover{border-color:oklch(0.72 0.17 156 / 0.45);color:oklch(0.86 0.09 156);background:oklch(0.72 0.17 156 / 0.08)}
 .side-panel-body::-webkit-scrollbar{width:10px}
 .side-panel-body::-webkit-scrollbar-thumb{background:#4a4a4a;border-radius:6px;border:3px solid var(--bg-sidebar)}
 .activity-more-item svg{width:15px;height:15px;color:var(--text-secondary)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9009,3 +9009,17 @@ body.platform-mac .tabbar { padding-right: 116px; }
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ── Activity bar ─────────────────────────────────────── */
+.activity-bar{width:48px;flex-shrink:0;background:var(--bg-activity);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;padding:6px 0}
+.activity-btn{width:48px;height:46px;display:flex;align-items:center;justify-content:center;color:#868686;position:relative;cursor:pointer;background:none;border:none}
+.activity-btn svg{width:22px;height:22px}
+.activity-btn:hover{color:#d6d6d6}
+.activity-btn.active{color:#fff}
+.activity-btn.active::before{content:'';position:absolute;left:0;top:9px;bottom:9px;width:2px;background:var(--accent)}
+.activity-badge{position:absolute;top:7px;right:7px;min-width:15px;height:15px;border-radius:8px;background:var(--accent);color:#fff;font-size:9px;font-weight:700;display:flex;align-items:center;justify-content:center;padding:0 3px;box-shadow:0 0 0 2px var(--bg-activity)}
+.activity-spacer{margin-top:auto}
+.activity-more-menu{position:fixed;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.45);padding:4px;min-width:170px;z-index:200}
+.activity-more-item{display:flex;align-items:center;gap:9px;width:100%;padding:7px 10px;border-radius:5px;background:none;border:none;color:var(--text-primary);font-size:13px;font-family:var(--font-ui);cursor:pointer;text-align:left}
+.activity-more-item:hover{background:var(--list-hover)}
+.activity-more-item svg{width:15px;height:15px;color:var(--text-secondary)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7282,41 +7282,46 @@ button.ci-badge:hover {
 }
 
 /* === Worktrees Section (Plan 1) === */
-.worktrees-section { padding: 8px 0; border-top: 1px solid var(--border); }
+.worktrees-section { padding: 4px 0 8px; }
 .wt-section-header {
   display: flex; justify-content: space-between; align-items: center;
-  padding: 6px 12px; color: var(--text-muted); font-size: 10px;
-  text-transform: uppercase; letter-spacing: 0.5px; cursor: pointer;
+  height: 24px; padding: 0 8px 0 16px; color: #8d8d8d; font-size: 11px;
+  font-weight: 600; text-transform: uppercase; letter-spacing: 0.07em;
+  cursor: pointer; user-select: none;
 }
 .wt-section-header:hover { color: var(--text-secondary); }
 .wt-add-btn {
-  background: transparent; border: none; color: var(--raven-blue);
-  font-size: 14px; cursor: pointer; padding: 0 4px;
+  width: 22px; height: 22px; display: flex; align-items: center; justify-content: center;
+  background: transparent; border: none; color: var(--text-muted); border-radius: 5px;
+  font-size: 15px; line-height: 1; cursor: pointer;
 }
-.wt-list { display: flex; flex-direction: column; }
+.wt-add-btn:hover { background: var(--list-hover); color: var(--text-primary); }
+.wt-list { display: flex; flex-direction: column; padding: 0 6px; }
 .wt-item {
-  display: flex; flex-direction: column; align-items: stretch; gap: 2px;
-  padding: 6px 12px; cursor: pointer; font-size: 12px;
-  color: var(--text-secondary);
+  display: flex; flex-direction: column; align-items: stretch; gap: 1px;
+  padding: 5px 8px; border-radius: 5px; cursor: pointer; font-size: 13px;
+  color: var(--text-secondary); position: relative;
 }
 .wt-item:hover { background: var(--list-hover); color: var(--text-primary); }
-.wt-item-active {
-  background: rgba(0, 102, 255, 0.10); color: var(--text-primary);
-  border-left: 2px solid var(--raven-blue); padding-left: 10px;
+.wt-item-active { background: var(--list-active); color: #fff; }
+.wt-item-active::before {
+  content: ''; position: absolute; left: 0; top: 5px; bottom: 5px;
+  width: 2px; background: var(--accent); border-radius: 2px;
 }
-.wt-item-main { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.wt-item-main { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .wt-dot {
-  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
 }
-.wt-dot-green { background: #00CC44; }
-.wt-dot-yellow { background: #FFB800; }
-.wt-dot-red { background: #FF1A1A; }
-.wt-dot-gray { background: #555; }
-.wt-branch { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.wt-dot-green { background: #3fb950; }
+.wt-dot-yellow { background: #d9c23a; }
+.wt-dot-red { background: #f85149; }
+.wt-dot-gray { background: #6e6e6e; }
+.wt-branch { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; font-size: 13px; }
 .wt-meta {
-  color: var(--text-muted); font-size: 9px; font-family: var(--font-mono);
+  margin-left: auto; color: var(--text-muted); font-size: 9px;
+  font-family: var(--font-mono); text-transform: uppercase; letter-spacing: .04em;
 }
-.wt-empty { padding: 6px 12px; color: var(--text-muted); font-size: 11px; font-style: italic; }
+.wt-empty { padding: 8px 16px; color: var(--text-muted); font-size: 12px; }
 
 /* Slug: directory basename under the branch line. Muted, monospace so it
    reads as "this is where it lives on disk", not as content. */
@@ -7324,7 +7329,7 @@ button.ci-badge:hover {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-muted);
-  padding-left: 12px; /* visually nests under the branch text */
+  padding-left: 15px; /* nests under the branch text */
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9056,4 +9056,22 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .tabbar-tool{width:30px;height:30px;border-radius:6px;display:flex;align-items:center;justify-content:center;color:var(--text-secondary);background:none;border:none;cursor:pointer}
 .tabbar-tool:hover{background:var(--list-hover);color:var(--text-primary)}
 .tabbar-tool.active{color:var(--accent)}
+
+/* ── Docked panel overrides ─────────────────────────────── */
+.snippet-panel--docked,
+.mcp-panel--docked,
+.workspace-panel--docked,
+.cmd-history-panel--docked {
+  position: static !important;
+  top: auto;
+  left: auto;
+  right: auto;
+  width: auto;
+  max-width: none;
+  max-height: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
 .tabbar-tool svg{width:17px;height:17px}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9050,3 +9050,10 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .side-panel-body::-webkit-scrollbar{width:10px}
 .side-panel-body::-webkit-scrollbar-thumb{background:#4a4a4a;border-radius:6px;border:3px solid var(--bg-sidebar)}
 .activity-more-item svg{width:15px;height:15px;color:var(--text-secondary)}
+
+/* ── Tab bar view controls ─────────────────────────────── */
+.tabbar-tools{display:flex;align-items:center;gap:2px;padding-right:4px}
+.tabbar-tool{width:30px;height:30px;border-radius:6px;display:flex;align-items:center;justify-content:center;color:var(--text-secondary);background:none;border:none;cursor:pointer}
+.tabbar-tool:hover{background:var(--list-hover);color:var(--text-primary)}
+.tabbar-tool.active{color:var(--accent)}
+.tabbar-tool svg{width:17px;height:17px}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -880,7 +880,7 @@ body {
   transition: border-color 0.15s, color 0.15s;
 }
 .team-switcher-btn:hover {
-  border-color: #444;
+  border-color: var(--border-strong);
   color: var(--text-primary);
 }
 
@@ -959,7 +959,7 @@ body {
   transition: background 0.1s;
 }
 .team-switcher-new:hover {
-  background: #0066FF15;
+  background: rgba(0, 102, 255, 0.08);
 }
 
 /* Pending invite banner (inside team, for second invite) */
@@ -1106,14 +1106,14 @@ body {
   transition: background 0.12s;
 }
 .team-member-row:hover {
-  background: var(--bg-surface);
+  background: var(--list-hover);
 }
 
 .team-member-avatar {
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: #0066FF22;
+  background: rgba(0, 102, 255, 0.13);
   color: var(--raven-blue);
   font-size: 12px;
   font-weight: 600;
@@ -3197,7 +3197,7 @@ body {
   border-radius: 50%;
   flex-shrink: 0;
   animation: shimmer 1.4s infinite;
-  background: linear-gradient(90deg, var(--bg-elevated) 25%, #1a1a1a 50%, var(--bg-elevated) 75%);
+  background: linear-gradient(90deg, var(--bg-elevated) 25%, var(--bg-app) 50%, var(--bg-elevated) 75%);
   background-size: 200% 100%;
 }
 
@@ -3213,7 +3213,7 @@ body {
   height: 11px;
   border-radius: 4px;
   animation: shimmer 1.4s infinite;
-  background: linear-gradient(90deg, var(--bg-elevated) 25%, #1a1a1a 50%, var(--bg-elevated) 75%);
+  background: linear-gradient(90deg, var(--bg-elevated) 25%, var(--bg-app) 50%, var(--bg-elevated) 75%);
   background-size: 200% 100%;
 }
 
@@ -6029,7 +6029,7 @@ button.ci-badge:hover {
 
 /* Message rows: subtle hover background */
 .chat-row.chat-row-message:hover {
-  background: rgba(255,255,255,0.03);
+  background: var(--list-hover);
 }
 
 /* Event rows: left border by type */
@@ -6038,7 +6038,7 @@ button.ci-badge:hover {
   padding-left: 13px;
 }
 .chat-row.chat-row-event:hover {
-  background: rgba(255,255,255,0.025);
+  background: var(--list-hover);
 }
 .chat-row.event-push    { border-left-color: #3b82f6; }
 .chat-row.event-pr      { border-left-color: #22c55e; }
@@ -6166,7 +6166,7 @@ button.ci-badge:hover {
 }
 .chat-reaction.mine {
   background: rgba(0, 102, 255, 0.14);
-  border-color: rgba(0, 102, 255, 0.45);
+  border-color: rgba(0, 102, 255, 0.4);
 }
 
 .chat-reaction-count {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,13 +8,30 @@
 :root {
   --raven-blue: #0066FF;
   --raven-blue-dim: #0066FF44;
-  --bg-app: #000000;
-  --bg-surface: #0a0a0a;
-  --bg-elevated: #111111;
-  --border: #1e1e1e;
-  --text-primary: #e8e8e8;
-  --text-secondary: #888;
-  --text-muted: #555;
+  --accent: var(--raven-blue);
+
+  /* Carbon layered surfaces (VS Code-style) */
+  --bg-app: #1e1e1e;        /* base / editor */
+  --bg-surface: #252526;    /* sidebar, panels, tabs */
+  --bg-sidebar: #252526;
+  --bg-elevated: #2d2d30;   /* popovers, modals */
+  --bg-titlebar: #323233;
+  --bg-pane: #181818;       /* terminal cell background */
+
+  --border: #2b2b2b;        /* subtle border */
+  --border-strong: #333333; /* visible border */
+
+  --text-primary: #d4d4d4;
+  --text-secondary: #969696;
+  --text-muted: #6a6a6a;
+
+  --list-hover: #2a2d2e;
+  --list-active: #37373d;
+
+  /* Typography */
+  --font-ui: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Consolas, monospace;
+
   --titlebar-height: 44px;
   --header-height: 32px;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,28 +14,32 @@
   --raven-blue: var(--accent);
   --raven-blue-dim: oklch(0.72 0.17 156 / 0.28);
 
-  /* Near-black layered surfaces (matches demo) */
-  --bg-app: oklch(0.155 0.004 240);      /* base behind panes */
-  --bg-surface: oklch(0.185 0.005 240);  /* sidebar, panels, tabs */
-  --bg-sidebar: oklch(0.175 0.005 240);
-  --bg-elevated: oklch(0.215 0.006 240); /* popovers, modals */
-  --bg-titlebar: oklch(0.205 0.005 240);
-  --bg-activity: oklch(0.165 0.005 240);
+  /* Near-black layered surfaces — values taken from nestmux.com (oklch hue 240,
+     deep cool near-black base with layered surfaces). */
+  --bg-app: oklch(0.135 0.005 240);      /* layer-0: base behind panes */
+  --bg-surface: oklch(0.175 0.005 240);  /* layer-1: sidebar, panels, tabs */
+  --bg-sidebar: oklch(0.165 0.005 240);
+  --bg-elevated: oklch(0.215 0.008 240); /* layer-2: popovers, modals */
+  --bg-titlebar: oklch(0.175 0.005 240);
+  --bg-activity: oklch(0.145 0.005 240);
   --bg-pane: #000000;                     /* terminal cells â€” black like the demo */
 
-  --border: oklch(1 0 0 / 0.07);         /* subtle border */
-  --border-strong: oklch(1 0 0 / 0.14);  /* visible border */
+  /* White-alpha borders in three tiers (matches nestmux --line-*) */
+  --border-subtle: oklch(1 0 0 / 0.06);
+  --border: oklch(1 0 0 / 0.10);         /* default border */
+  --border-strong: oklch(1 0 0 / 0.16);  /* visible border */
 
-  --text-primary: oklch(0.95 0 0);
-  --text-secondary: oklch(0.66 0 0);
-  --text-muted: oklch(0.48 0 0);
+  --text-primary: oklch(0.98 0 0);
+  --text-secondary: oklch(0.72 0 0);
+  --text-muted: oklch(0.55 0 0);
 
-  --list-hover: oklch(1 0 0 / 0.05);
-  --list-active: oklch(1 0 0 / 0.09);
+  --list-hover: oklch(1 0 0 / 0.06);
+  --list-active: oklch(1 0 0 / 0.10);
 
-  /* Typography */
-  --font-ui: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', ui-monospace, 'Cascadia Code', Consolas, monospace;
+  /* Typography — Inter (UI) + Geist Mono, bundled via @fontsource (offline-safe),
+     matching nestmux.com. */
+  --font-ui: 'Inter Variable', 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'Geist Mono Variable', 'Geist Mono', ui-monospace, 'Cascadia Code', Consolas, monospace;
 
   --color-success: #22C55E;
 
@@ -4041,10 +4045,10 @@ body {
 }
 
 .empty-title {
-  font-size: 28px;
-  font-weight: 700;
+  font-size: 30px;
+  font-weight: 600;
   color: var(--text-primary);
-  letter-spacing: 1px;
+  letter-spacing: -0.022em;
 }
 
 .empty-title .raven {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-/* RAVEN Nest — Global Styles */
+﻿/* RAVEN Nest â€” Global Styles */
 
 @keyframes spin {
   from { transform: rotate(0deg); }
@@ -6,7 +6,7 @@
 }
 
 :root {
-  /* Brand accent — emerald + cyan (matches nestmux.com demo).
+  /* Brand accent â€” emerald + cyan (matches nestmux.com demo).
      Legacy name --raven-blue kept so existing var(--raven-blue) usages follow. */
   --accent: oklch(0.72 0.17 156);
   --accent-hover: oklch(0.66 0.18 156);
@@ -21,7 +21,7 @@
   --bg-elevated: oklch(0.215 0.006 240); /* popovers, modals */
   --bg-titlebar: oklch(0.205 0.005 240);
   --bg-activity: oklch(0.165 0.005 240);
-  --bg-pane: #000000;                     /* terminal cells — black like the demo */
+  --bg-pane: #000000;                     /* terminal cells â€” black like the demo */
 
   --border: oklch(1 0 0 / 0.07);         /* subtle border */
   --border-strong: oklch(1 0 0 / 0.14);  /* visible border */
@@ -67,14 +67,14 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-/* No-select on UI chrome only — never on terminal area */
+/* No-select on UI chrome only â€” never on terminal area */
 .tabbar, .pane-header, .dialog, .layout-popover,
 .snippet-panel, .empty-state, .empty-cell {
   user-select: none;
   -webkit-user-select: none;
 }
 
-/* ── App Layout ─────────────────────────────────────────── */
+/* â”€â”€ App Layout â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .app {
   display: flex;
@@ -117,7 +117,7 @@ body {
 .status-item-end { margin-left: auto; }
 
 
-/* ── Tab Bar ─────────────────────────────────────────────── */
+/* â”€â”€ Tab Bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .tabbar {
   height: var(--titlebar-height);
@@ -333,7 +333,7 @@ body {
   50% { opacity: 0.4; transform: scale(0.8); }
 }
 
-/* ── Sidebar ─────────────────────────────────────────────── */
+/* â”€â”€ Sidebar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .sidebar {
   flex-shrink: 0;
@@ -348,7 +348,7 @@ body {
   z-index: 10;
 }
 
-/* Scrollable middle section of the sidebar — keeps top toggle and bottom user menu /
+/* Scrollable middle section of the sidebar â€” keeps top toggle and bottom user menu /
    settings pinned while letting the rest scroll when the window is short. Popovers
    inside scroll items use position:fixed (see useFixedPopover) to escape this clip. */
 .sidebar-scroll {
@@ -381,7 +381,7 @@ body {
 }
 .sidebar-scroll::-webkit-scrollbar-button { display: none; }
 
-/* ── Global scrollbar theme ─────────────────────────────────
+/* â”€â”€ Global scrollbar theme â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
    Minimalist dark scrollbars: invisible by default, fade in when the user
    hovers the scrollable area. Applies to every scrollable element in the
    renderer (Chromium WebKit + Firefox). Specific containers can still
@@ -599,11 +599,11 @@ body {
   margin-bottom: 4px;
 }
 
-/* ── Sidebar popover overrides ───────────────────────────────
+/* â”€â”€ Sidebar popover overrides â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
    SnippetPanel and LayoutPicker were designed for the Titlebar
    (popovers open downward, right-aligned). In the sidebar they
    must open rightward instead.
-   ─────────────────────────────────────────────────────────── */
+   â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 /* Make wrapper divs non-positioning contexts so popovers anchor
    to .sidebar-item-panel (which IS position:relative) */
@@ -614,7 +614,7 @@ body {
   position: static;
 }
 
-/* Hide the internal trigger buttons — the sidebar row IS the trigger.
+/* Hide the internal trigger buttons â€” the sidebar row IS the trigger.
    We overlay the button over the full row (inset:0) so clicking
    anywhere on the row opens the panel. */
 .sidebar .snippet-wrap > button.titlebar-btn,
@@ -637,7 +637,7 @@ body {
   position: relative;
 }
 
-/* Team / Settings modal trigger — same overlay trick */
+/* Team / Settings modal trigger â€” same overlay trick */
 .sidebar-item-team > button.titlebar-btn,
 .sidebar-item-settings > button.titlebar-btn {
   position: absolute;
@@ -682,14 +682,14 @@ body {
   right: auto;
 }
 
-/* ── Sidebar Superset-style layout (v1.0) ──────────────────
+/* â”€â”€ Sidebar Superset-style layout (v1.0) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
    Top: repo header. Middle: WorktreesSection (foco principal, flex-grow
    con min-height grande para que no se achique cuando "More tools" abre).
    Below: Teams + My Repos. Bottom: More tools (collapsible con scroll
    interno) + New Terminal. */
 
-/* Wrap around WorktreesSection — toma todo el espacio sobrante del scroll
-   area pero NUNCA baja de un mínimo grande, para que el desplegable de
+/* Wrap around WorktreesSection â€” toma todo el espacio sobrante del scroll
+   area pero NUNCA baja de un mÃ­nimo grande, para que el desplegable de
    abajo no aplaste los worktrees. */
 .sidebar-worktrees-wrap {
   flex: 1 1 auto;
@@ -700,7 +700,7 @@ body {
   padding-top: 4px;
 }
 
-/* Separador sutil entre la sección de worktrees y Teams/MyRepos. */
+/* Separador sutil entre la secciÃ³n de worktrees y Teams/MyRepos. */
 .sidebar-section-divider {
   height: 1px;
   background: var(--border);
@@ -708,9 +708,9 @@ body {
   flex-shrink: 0;
 }
 
-/* Desplegable "More tools" — header siempre visible, contenido con scroll
+/* Desplegable "More tools" â€” header siempre visible, contenido con scroll
    interno cuando abierto. flex-shrink:0 + max-height en la lista hace que
-   no robe altura a la sección de worktrees. */
+   no robe altura a la secciÃ³n de worktrees. */
 .sidebar-more {
   flex-shrink: 0;
   display: flex;
@@ -746,8 +746,8 @@ body {
   background: var(--bg-elevated);
 }
 
-/* New Terminal — acción primaria al fondo del scroll. Tipografía ligeramente
-   más destacada para que se lea como CTA. */
+/* New Terminal â€” acciÃ³n primaria al fondo del scroll. TipografÃ­a ligeramente
+   mÃ¡s destacada para que se lea como CTA. */
 .sidebar-new-terminal {
   flex-shrink: 0;
   color: var(--text-primary);
@@ -758,7 +758,7 @@ body {
 }
 
 /* En modo colapsado (sin .expanded) la sidebar es de 44px y los labels van
-   ocultos: aseguramos que las secciones nuevas también escondan separador
+   ocultos: aseguramos que las secciones nuevas tambiÃ©n escondan separador
    y borders sobrantes para no romper el look minimal. */
 .sidebar:not(.expanded) .sidebar-section-divider {
   margin: 6px 8px;
@@ -769,7 +769,7 @@ body {
   background: transparent;
 }
 
-/* ── Grid Workspace ─────────────────────────────────────── */
+/* â”€â”€ Grid Workspace â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .grid-workspace {
   flex: 1;
@@ -778,7 +778,7 @@ body {
   overflow: hidden;
 }
 
-/* react-resizable-panels — make each Panel a flex container so children fill it */
+/* react-resizable-panels â€” make each Panel a flex container so children fill it */
 .grid-workspace [data-panel] {
   display: flex !important;
   flex-direction: column;
@@ -817,9 +817,9 @@ body {
   font-size: 12px;
 }
 
-/* ── Layout Picker ───────────────────────────────────────── */
+/* â”€â”€ Layout Picker â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
-/* ── Snippets ────────────────────────────────────────────── */
+/* â”€â”€ Snippets â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .snippet-wrap {
   position: relative;
@@ -838,7 +838,7 @@ body {
   overflow: hidden;
 }
 
-/* ── Team Modal ──────────────────────────────────────────── */
+/* â”€â”€ Team Modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-modal-overlay {
   position: fixed;
@@ -1352,7 +1352,7 @@ body {
 }
 
 .snippet-name {
-  /* MUST be block (or inline-block) so the ellipsis chain works — inline
+  /* MUST be block (or inline-block) so the ellipsis chain works â€” inline
      elements ignore `overflow: hidden` and `text-overflow: ellipsis`. Without
      `display: block` here, long repo names like "Sti-Project/sti-travel-console"
      overflow visually past their container and render UNDERNEATH the action
@@ -1410,7 +1410,7 @@ body {
 
 .snippet-delete-btn:hover { color: #EF4444; }
 
-/* ── Conversation Sidebar ────────────────────────────────── */
+/* â”€â”€ Conversation Sidebar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .conv-overlay {
   position: fixed;
@@ -1756,7 +1756,7 @@ body {
   color: #22C55E;
 }
 
-/* ── Layout Picker ───────────────────────────────────────── */
+/* â”€â”€ Layout Picker â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .layout-picker-wrap {
   position: relative;
@@ -1835,7 +1835,7 @@ body {
   color: var(--raven-blue);
 }
 
-/* ── Terminal Pane ───────────────────────────────────────── */
+/* â”€â”€ Terminal Pane â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .terminal-pane {
   display: flex;
@@ -1991,7 +1991,7 @@ body {
   border-color: #0066FF88;
 }
 
-/* Sync cwd button — live pane cwd diverges from active repo */
+/* Sync cwd button â€” live pane cwd diverges from active repo */
 .pane-sync-cwd-btn {
   display: flex;
   align-items: center;
@@ -2036,7 +2036,7 @@ body {
   color: var(--raven-blue);
 }
 
-/* ── Drag & Drop ─────────────────────────────────────────── */
+/* â”€â”€ Drag & Drop â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .pane-header {
   position: relative;
@@ -2063,7 +2063,7 @@ body {
 }
 
 .pane-drag-handle::before {
-  content: '⠿';
+  content: 'â ¿';
   font-size: 14px;
   color: var(--text-muted);
   line-height: 1;
@@ -2284,7 +2284,7 @@ body {
   display: none;
 }
 
-/* ── FileStagingBar ──────────────────────────────────────── */
+/* â”€â”€ FileStagingBar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .file-staging-bar {
   flex-shrink: 0;
@@ -2385,7 +2385,7 @@ body {
   background: #0055dd;
 }
 
-/* ── ConfirmDialog ───────────────────────────────────────── */
+/* â”€â”€ ConfirmDialog â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .confirm-overlay {
   position: fixed;
@@ -2457,7 +2457,7 @@ body {
   color: #FF4444;
 }
 
-/* ── PR / Issue / Activity Feed ──────────────────────────── */
+/* â”€â”€ PR / Issue / Activity Feed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 /* Shared: avatar inline */
 .pr-avatar {
@@ -2539,7 +2539,7 @@ body {
   100% { background-position: -200% 0; }
 }
 
-/* ── PRList ──────────────────────────────────────────────── */
+/* â”€â”€ PRList â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .pr-list-container {
   display: flex;
@@ -2705,7 +2705,7 @@ body {
   cursor: not-allowed;
 }
 
-/* ── PRReview ────────────────────────────────────────────── */
+/* â”€â”€ PRReview â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .pr-review-container {
   display: flex;
@@ -2931,7 +2931,7 @@ body {
   flex-wrap: wrap;
 }
 
-/* ── IssueList ───────────────────────────────────────────── */
+/* â”€â”€ IssueList â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .issue-list-container {
   display: flex;
@@ -3013,7 +3013,7 @@ body {
   white-space: nowrap;
 }
 
-/* ── IssueDetail ─────────────────────────────────────────── */
+/* â”€â”€ IssueDetail â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .issue-detail-container {
   display: flex;
@@ -3088,7 +3088,7 @@ body {
   border-color: #22c55e44 !important;
 }
 
-/* ── ActivityFeed ────────────────────────────────────────── */
+/* â”€â”€ ActivityFeed â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .feed-container {
   display: flex;
@@ -3252,7 +3252,7 @@ body {
   opacity: 0.85;
 }
 
-/* ── Resize Handle ───────────────────────────────────────── */
+/* â”€â”€ Resize Handle â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .resize-handle {
   background: transparent;
@@ -3281,7 +3281,7 @@ body {
   pointer-events: none;
 }
 
-/* ── Blocks View ─────────────────────────────────────────── */
+/* â”€â”€ Blocks View â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .blocks-view {
   flex: 1;
@@ -3431,7 +3431,7 @@ body {
   opacity: 0.9;
 }
 
-/* ── AI Card locked state ────────────────────────────────── */
+/* â”€â”€ AI Card locked state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .ai-card.locked {
   opacity: 0.4;
@@ -3457,7 +3457,7 @@ body {
   letter-spacing: 0.5px;
 }
 
-/* ── Upgrade Modal ───────────────────────────────────────── */
+/* â”€â”€ Upgrade Modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .modal-backdrop {
   position: fixed;
@@ -3747,7 +3747,7 @@ body {
   cursor: not-allowed;
 }
 
-/* ── Update Banner ───────────────────────────────────────── */
+/* â”€â”€ Update Banner â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .update-banner {
   display: flex;
@@ -3793,7 +3793,7 @@ body {
   background: #22C55E33;
 }
 
-/* ── Auth Screen ─────────────────────────────────────────── */
+/* â”€â”€ Auth Screen â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 /* Always-present OS drag region at the top of every screen */
 .global-titlebar-drag {
@@ -4006,7 +4006,7 @@ body {
   color: var(--text-secondary);
 }
 
-/* ── Empty State ─────────────────────────────────────────── */
+/* â”€â”€ Empty State â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .empty-state {
   display: flex;
@@ -4060,7 +4060,7 @@ kbd {
   font-family: inherit;
 }
 
-/* ── Buttons ─────────────────────────────────────────────── */
+/* â”€â”€ Buttons â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .btn-primary {
   background: var(--raven-blue);
@@ -4083,7 +4083,7 @@ kbd {
   cursor: not-allowed;
 }
 
-/* ── Dialog ──────────────────────────────────────────────── */
+/* â”€â”€ Dialog â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .dialog-overlay {
   position: fixed;
@@ -4147,7 +4147,7 @@ kbd {
   color: var(--text-primary);
 }
 
-/* ── AI Grid ─────────────────────────────────────────────── */
+/* â”€â”€ AI Grid â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .ai-grid {
   display: grid;
@@ -4252,7 +4252,7 @@ kbd {
   color: #fff;
 }
 
-/* ── Account List ────────────────────────────────────────── */
+/* â”€â”€ Account List â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .account-list {
   margin-bottom: 20px;
@@ -4316,7 +4316,7 @@ kbd {
   background: rgba(239, 68, 68, 0.1);
 }
 
-/* ── New Account Form ────────────────────────────────────── */
+/* â”€â”€ New Account Form â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .new-account-form {
   border-top: 1px solid var(--border);
@@ -4356,7 +4356,7 @@ kbd {
   line-height: 1.5;
 }
 
-/* ── Color Picker ────────────────────────────────────────── */
+/* â”€â”€ Color Picker â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .color-picker-section {
   margin-top: 16px;
@@ -4391,7 +4391,7 @@ kbd {
   box-shadow: 0 0 0 2px rgba(255,255,255,0.3);
 }
 
-/* ── Global Search ───────────────────────────────────────── */
+/* â”€â”€ Global Search â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .global-search-overlay {
   position: fixed;
@@ -4527,7 +4527,7 @@ kbd {
   font-family: inherit;
 }
 
-/* ── Command Palette ─────────────────────────────────────── */
+/* â”€â”€ Command Palette â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .cmd-overlay {
   position: fixed;
@@ -4660,7 +4660,7 @@ kbd {
   margin-right: 3px;
 }
 
-/* ── MCP Panel ───────────────────────────────────────────── */
+/* â”€â”€ MCP Panel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .mcp-wrap {
   position: relative;
@@ -4964,9 +4964,9 @@ kbd {
   }
 }
 
-/* ══════════════════════════════════════
+/* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    TEAMS WORKSPACE (full-screen overlay)
-══════════════════════════════════════ */
+â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â• */
 
 .teams-workspace {
   position: fixed;
@@ -5241,7 +5241,7 @@ kbd {
   color: var(--text-secondary);
 }
 
-/* ── Notification Panel ─────────────────────────────────── */
+/* â”€â”€ Notification Panel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .notification-panel {
   position: absolute;
@@ -5381,7 +5381,7 @@ kbd {
   margin-top: 5px;
 }
 
-/* ── CI Status Badge ─────────────────────────────────────── */
+/* â”€â”€ CI Status Badge â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .ci-badge {
   display: inline-flex;
@@ -5451,7 +5451,7 @@ button.ci-badge:hover {
   50%       { opacity: 0.35; transform: scale(0.75); }
 }
 
-/* Teams Workspace — header right & subnav */
+/* Teams Workspace â€” header right & subnav */
 .tw-header-right {
   display: flex;
   align-items: center;
@@ -5536,7 +5536,7 @@ button.ci-badge:hover {
   color: var(--text-secondary);
 }
 
-/* ── Daily Standup ───────────────────────────────────────── */
+/* â”€â”€ Daily Standup â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .standup-container {
   display: flex;
@@ -5594,7 +5594,7 @@ button.ci-badge:hover {
 }
 
 .standup-member-activity li::before {
-  content: '•';
+  content: 'â€¢';
   position: absolute;
   left: 0;
   color: var(--text-muted);
@@ -5797,7 +5797,7 @@ button.ci-badge:hover {
   border-color: #0052cc;
 }
 
-/* ── Repo actions overflow menu (⋯) ──────────────────────── */
+/* â”€â”€ Repo actions overflow menu (â‹¯) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .repo-menu-wrap {
   position: relative;
   display: inline-flex;
@@ -5861,7 +5861,7 @@ button.ci-badge:hover {
   flex-shrink: 0;
 }
 
-/* ── Repo list scroll wrapper ────────────────────────────── */
+/* â”€â”€ Repo list scroll wrapper â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .repo-list-scroll {
   max-height: calc(100vh - 280px);
   overflow-y: auto;
@@ -5879,7 +5879,7 @@ button.ci-badge:hover {
 .repo-list-scroll:hover::-webkit-scrollbar-thumb { background: rgba(128,128,128,0.3); }
 .repo-list-scroll::-webkit-scrollbar-thumb:hover { background: rgba(128,128,128,0.5); }
 
-/* ── Repo action buttons — unified system ────────────────── */
+/* â”€â”€ Repo action buttons â€” unified system â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .repo-action-btn {
   display: inline-flex;
   align-items: center;
@@ -5945,7 +5945,7 @@ button.ci-badge:hover {
   opacity: 0.85;
 }
 
-/* ── Placeholder typography helpers ──────────────────────── */
+/* â”€â”€ Placeholder typography helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .tw-placeholder-title {
   font-size: 13px;
   font-weight: 500;
@@ -5956,7 +5956,7 @@ button.ci-badge:hover {
   margin-bottom: 14px;
 }
 
-/* ── Provider avatar pill (header de MyRepos / Teams) ───── */
+/* â”€â”€ Provider avatar pill (header de MyRepos / Teams) â”€â”€â”€â”€â”€ */
 .tw-provider-avatars {
   display: inline-flex;
   align-items: center;
@@ -6304,7 +6304,7 @@ button.ci-badge:hover {
   color: #ef4444;
 }
 
-/* ── RepoStatusPanel ─────────────────────────────────────── */
+/* â”€â”€ RepoStatusPanel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .repo-status-panel {
   display: flex;
   flex-direction: column;
@@ -6457,7 +6457,7 @@ button.ci-badge:hover {
 }
 .rsp-refresh:disabled { opacity: 0.4; cursor: not-allowed; }
 
-/* ── Settings Panel ──────────────────────────────────────── */
+/* â”€â”€ Settings Panel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .sp-modal {
   position: fixed;
@@ -6696,7 +6696,7 @@ button.ci-badge:hover {
 .sp-action-btn:hover:not(:disabled) { background: var(--bg-elevated); color: var(--text-primary); }
 .sp-action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
-/* ── Terminal Share Panel ────────────────────────────────── */
+/* â”€â”€ Terminal Share Panel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .ts-panel {
   width: 280px;
@@ -6753,7 +6753,7 @@ button.ci-badge:hover {
   font-family: var(--font-mono);
 }
 
-/* ── User menu (sidebar avatar + popover) ─────────────────── */
+/* â”€â”€ User menu (sidebar avatar + popover) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .user-menu-trigger {
   display: flex;
@@ -6989,7 +6989,7 @@ button.ci-badge:hover {
   border-color: rgba(255,80,80,0.3);
 }
 
-/* ── Repo Actions (B accordion + D bar) ──────────────────── */
+/* â”€â”€ Repo Actions (B accordion + D bar) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .actions-accordion {
   display: flex;
@@ -7339,7 +7339,7 @@ button.ci-badge:hover {
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 
-/* +X / -Y diff chip — green/red tones tuned to read on the dark sidebar. */
+/* +X / -Y diff chip â€” green/red tones tuned to read on the dark sidebar. */
 .wt-diff-chip {
   display: inline-flex; align-items: center; gap: 4px;
   font-family: var(--font-mono); font-size: 10px;
@@ -7348,7 +7348,7 @@ button.ci-badge:hover {
 .wt-diff-add { color: #4ade80; }
 .wt-diff-del { color: #f87171; }
 
-/* PR badge — subtle indigo so it doesn't compete with status dot or spotlight. */
+/* PR badge â€” subtle indigo so it doesn't compete with status dot or spotlight. */
 .wt-pr-chip {
   display: inline-flex; align-items: center;
   background: rgba(68, 85, 255, 0.12);
@@ -7368,7 +7368,7 @@ button.ci-badge:hover {
   color: #b6c2ff;
 }
 
-/* ── NewWorktreeModal ────────────────────────────────────── */
+/* â”€â”€ NewWorktreeModal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .new-worktree-modal { width: 480px; }
 .dialog-sub { color: var(--text-muted); font-size: 11px; margin-bottom: 16px; }
@@ -7389,7 +7389,7 @@ button.ci-badge:hover {
   font-size: 11px; border-radius: 4px;
 }
 
-/* .env carry-over warning in NewWorktreeModal — uses the same amber tone as
+/* .env carry-over warning in NewWorktreeModal â€” uses the same amber tone as
    .pane-sync-cwd-btn and .rb-heavy-banner so all "watch out" hints look alike. */
 .wt-env-banner {
   margin-top: 14px;
@@ -7412,7 +7412,7 @@ button.ci-badge:hover {
   color: #FFB800cc;
 }
 .wt-env-banner-list li { line-height: 1.5; }
-.wt-env-banner-list li::before { content: '• '; }
+.wt-env-banner-list li::before { content: 'â€¢ '; }
 .wt-env-banner-copy {
   display: flex; align-items: center; gap: 6px;
   margin-top: 8px;
@@ -7590,7 +7590,7 @@ button.ci-badge:hover {
 }
 
 /* Shown in place of the (now-collapsed) WebContentsView when the user
-   attempts to navigate to Nest's own dev/renderer origin — see isOwnOrigin
+   attempts to navigate to Nest's own dev/renderer origin â€” see isOwnOrigin
    in BrowserCell.tsx. The matching selector in OVERLAY_SELECTOR collapses
    the native WebContentsView so this DOM overlay isn't covered. */
 .browser-self-origin-overlay {
@@ -7740,7 +7740,7 @@ button.ci-badge:hover {
 .ide-picker-divider { height: 1px; background: var(--border); margin: 4px 0; }
 .ide-picker-redetect { color: var(--text-secondary); font-size: 11px; }
 
-/* ── Resource Usage (titlebar pill + popover) ────────────────── */
+/* â”€â”€ Resource Usage (titlebar pill + popover) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 /* Floats over the tabbar's right edge, before the Windows native titlebar
    overlay (~138px reserved for min/max/close). Position fixed because the
@@ -8005,7 +8005,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .rb-bullet-logo {
-/* ── Empty state: Join / Create tabs ─────────────────────────────── */
+/* â”€â”€ Empty state: Join / Create tabs â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .empty-state-wrap {
   width: 100%;
@@ -8134,7 +8134,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   background: var(--border);
 }
 
-/* ── Join by code form ───────────────────────────────────────────── */
+/* â”€â”€ Join by code form â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .join-code-form {
   display: flex;
@@ -8182,7 +8182,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 8px;
 }
 
-/* ── Team join code panel (Members tab) ──────────────────────────── */
+/* â”€â”€ Team join code panel (Members tab) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-join-code-panel {
   display: flex;
@@ -8266,13 +8266,13 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 .team-join-code-icon-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
-/* ── Member status: requested ────────────────────────────────────── */
+/* â”€â”€ Member status: requested â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-member-status.requested {
   color: var(--raven-blue);
 }
 
-/* ── Switcher item: Join with code icon hue ──────────────────────── */
+/* â”€â”€ Switcher item: Join with code icon hue â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-switcher-item-icon {
   display: inline-flex;
@@ -8289,7 +8289,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   height: 11px;
 }
 
-/* Browser URL port picker — dropdown of listening ports detected
+/* Browser URL port picker â€” dropdown of listening ports detected
    across every live pane's process tree. */
 .browser-port-wrap {
   position: relative;
@@ -8402,7 +8402,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   letter-spacing: 0.02em;
 }
 
-/* Heaviest-pane callout — same amber tone the .pane-sync-cwd-btn uses so the
+/* Heaviest-pane callout â€” same amber tone the .pane-sync-cwd-btn uses so the
    warning hue is consistent across the app. Sits above totals when fired. */
 .rb-heavy-banner {
   display: flex;
@@ -8441,7 +8441,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-size: 11px;
 }
 
-/* Port chips next to a worktree branch label — small monospace tags so they
+/* Port chips next to a worktree branch label â€” small monospace tags so they
    read like "address-y" annotations rather than another metric value. */
 .rb-port-chips {
   display: inline-flex;
@@ -8462,7 +8462,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-variant-numeric: tabular-nums;
 }
 
-/* Per-pane kill button — hidden until the row is hovered to keep the tree
+/* Per-pane kill button â€” hidden until the row is hovered to keep the tree
    visually quiet. The grandchild row already has padding-left so the metric
    text sits where users expect; the button reserves a fixed 18px slot at the
    right edge instead of shifting the metric on hover. */
@@ -8527,7 +8527,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   pointer-events: none;
 }
 
-/* Disk bucket rows shown under an expanded worktree — same grandchild indent
+/* Disk bucket rows shown under an expanded worktree â€” same grandchild indent
    as panes, muted text + right-aligned monospace size so the eye lines up
    the numbers across rows. No hover interaction (read-only breakdown). */
 .rb-bucket-row {
@@ -8553,7 +8553,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   opacity: 0.5;
 }
 
-/* Inline bucket summary on the repo header (top 3) — collapses to dots when
+/* Inline bucket summary on the repo header (top 3) â€” collapses to dots when
    tight, gets the muted treatment so it reads as metadata, not a metric. */
 .rb-bucket-inline {
   margin-left: 4px;
@@ -8577,7 +8577,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 /* 3-segment pane label separator. The middle dot stays muted so the eye can
-   pick out the segments (cli · account · pid) without the row looking like a
+   pick out the segments (cli Â· account Â· pid) without the row looking like a
    sentence. accountName uses text-secondary (slightly brighter than muted)
    so two panes from the same CLI but different accounts pop visually. */
 .rb-label-sep {
@@ -8620,7 +8620,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 /* ==========================================================================
-   TeamJoinCodePanel — redesigned (tjcp-*)
+   TeamJoinCodePanel â€” redesigned (tjcp-*)
    Mac-minimal: subtle border, soft surface, generous tracking labels.
    ========================================================================== */
 .tjcp-card {
@@ -8784,7 +8784,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 /* ==========================================================================
-   JoinByCodeForm — redesigned (jcf-*)
+   JoinByCodeForm â€” redesigned (jcf-*)
    Minimal, modern: monospace hero input, full-width primary CTA below.
    ========================================================================== */
 .jcf-root {
@@ -9021,7 +9021,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   cursor: not-allowed;
 }
 
-/* ── Activity bar ─────────────────────────────────────── */
+/* â”€â”€ Activity bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .activity-bar{width:48px;flex-shrink:0;background:var(--bg-activity);border-right:1px solid var(--border);display:flex;flex-direction:column;align-items:center;padding:6px 0}
 .activity-btn{width:48px;height:46px;display:flex;align-items:center;justify-content:center;color:#868686;position:relative;cursor:pointer;background:none;border:none}
 .activity-btn svg{width:22px;height:22px}
@@ -9034,7 +9034,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .activity-more-item{display:flex;align-items:center;gap:9px;width:100%;padding:7px 10px;border-radius:5px;background:none;border:none;color:var(--text-primary);font-size:13px;font-family:var(--font-ui);cursor:pointer;text-align:left}
 .activity-more-item:hover{background:var(--list-hover)}
 
-/* ── Docked side panel ────────────────────────────────── */
+/* â”€â”€ Docked side panel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .side-panel{width:266px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0}
 .side-panel-head{display:flex;align-items:center;height:35px;padding:0 6px 0 16px;flex-shrink:0}
 .side-panel-head .ttl{font-size:11px;font-weight:600;letter-spacing:.09em;color:#bdbdbd;text-transform:uppercase}
@@ -9062,13 +9062,13 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .side-panel-body::-webkit-scrollbar-thumb{background:#4a4a4a;border-radius:6px;border:3px solid var(--bg-sidebar)}
 .activity-more-item svg{width:15px;height:15px;color:var(--text-secondary)}
 
-/* ── Tab bar view controls ─────────────────────────────── */
+/* â”€â”€ Tab bar view controls â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .tabbar-tools{display:flex;align-items:center;gap:2px;padding-right:4px}
 .tabbar-tool{width:30px;height:30px;border-radius:6px;display:flex;align-items:center;justify-content:center;color:var(--text-secondary);background:none;border:none;cursor:pointer}
 .tabbar-tool:hover{background:var(--list-hover);color:var(--text-primary)}
 .tabbar-tool.active{color:var(--accent)}
 
-/* ── Docked panel overrides ─────────────────────────────── */
+/* â”€â”€ Docked panel overrides â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 .snippet-panel--docked,
 .mcp-panel--docked,
 .workspace-panel--docked,
@@ -9086,3 +9086,21 @@ body.platform-mac .tabbar { padding-right: 116px; }
   background: transparent;
 }
 .tabbar-tool svg{width:17px;height:17px}
+n.nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0;padding:6px 0}n.nav-item{display:flex;align-items:center;gap:11px;height:34px;padding:0 11px;border-radius:7px;color:var(--text-secondary);font-size:13px;font-family:var(--font-ui);background:none;border:none;cursor:pointer;width:100%;text-align:left;position:relative}n.nav-item:hover{background:var(--list-hover);color:var(--text-primary)}n.nav-item.active{background:oklch(0.72 0.17 156 / 0.13);color:oklch(0.85 0.13 156);font-weight:500}n.nav-item-label{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}n.nav-item-primary{color:oklch(0.82 0.14 156)}n.nav-content{flex:1;min-height:0;overflow-y:auto;margin-top:6px;border-top:1px solid var(--border);padding-top:4px}n.nav-content::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}n
+/* ── Labeled nav sidebar (Teams-style) ─────────────────────────────────── */
+.nav-sidebar{width:226px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0;padding:6px 0}
+.nav-group{display:flex;flex-direction:column;flex-shrink:0;padding:0 8px;gap:1px}
+.nav-item{display:flex;align-items:center;gap:11px;height:34px;padding:0 11px;border-radius:7px;color:var(--text-secondary);font-size:13px;font-family:var(--font-ui);background:none;border:none;cursor:pointer;width:100%;text-align:left;position:relative}
+.nav-item svg{width:17px;height:17px;color:var(--text-muted);flex-shrink:0;stroke-width:1.7}
+.nav-item:hover{background:var(--list-hover);color:var(--text-primary)}
+.nav-item:hover svg{color:var(--text-secondary)}
+.nav-item.active{background:oklch(0.72 0.17 156 / 0.13);color:oklch(0.85 0.13 156);font-weight:500}
+.nav-item.active svg{color:oklch(0.80 0.15 156)}
+.nav-item-label{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.nav-item-badge{margin-left:auto;background:var(--accent);color:#04130c;font-size:10px;font-weight:700;min-width:16px;height:16px;border-radius:8px;display:flex;align-items:center;justify-content:center;padding:0 4px}
+.nav-item-primary{color:oklch(0.82 0.14 156)}
+.nav-item-primary svg{color:oklch(0.80 0.15 156)}
+.nav-content{flex:1;min-height:0;overflow-y:auto;margin-top:6px;border-top:1px solid var(--border);padding-top:4px}
+.nav-content::-webkit-scrollbar{width:10px}
+.nav-content::-webkit-scrollbar-thumb{background:#ffffff1a;border-radius:6px;border:3px solid var(--bg-sidebar)}
+.nav-footer{flex-shrink:0;border-top:1px solid var(--border);margin-top:6px;padding:4px 8px 0;display:flex;flex-direction:column;gap:1px}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -838,6 +838,17 @@ body {
   overflow: hidden;
 }
 
+.nav-popover {
+  width: 300px;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  z-index: 300;
+}
+
 /* â”€â”€ Team Modal â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
 
 .team-modal-overlay {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1320,7 +1320,7 @@ body {
 }
 
 .snippet-item:hover {
-  background: #ffffff06;
+  background: var(--list-hover);
 }
 
 .snippet-name {
@@ -2560,11 +2560,11 @@ body {
 .pr-filter-btn.active {
   background: var(--raven-blue-dim);
   color: var(--raven-blue);
-  border-color: #0066FF55;
+  border-color: var(--raven-blue-dim);
 }
 
 .pr-filter-btn:not(.active):hover {
-  background: #ffffff0a;
+  background: var(--list-hover);
   color: var(--text-primary);
 }
 
@@ -2592,7 +2592,7 @@ body {
   gap: 8px;
 }
 
-.pr-item:hover { background: #ffffff06; }
+.pr-item:hover { background: var(--list-hover); }
 
 .pr-item-left {
   display: flex;
@@ -2945,11 +2945,11 @@ body {
 .issue-filter-btn.active {
   background: var(--raven-blue-dim);
   color: var(--raven-blue);
-  border-color: #0066FF55;
+  border-color: var(--raven-blue-dim);
 }
 
 .issue-filter-btn:not(.active):hover {
-  background: #ffffff0a;
+  background: var(--list-hover);
   color: var(--text-primary);
 }
 
@@ -3078,7 +3078,7 @@ body {
   transition: background 0.1s;
 }
 
-.feed-event:hover { background: #ffffff05; }
+.feed-event:hover { background: var(--list-hover); }
 
 .feed-avatar {
   width: 36px;
@@ -5787,7 +5787,7 @@ button.ci-badge:hover {
   top: calc(100% + 4px);
   right: 0;
   min-width: 160px;
-  background: var(--bg-elevated, #1a1a1a);
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
@@ -5813,7 +5813,7 @@ button.ci-badge:hover {
   transition: background 0.12s ease, color 0.12s ease;
 }
 .repo-menu-item:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--list-hover);
   color: var(--text-primary);
 }
 .repo-menu-item:disabled {
@@ -5859,7 +5859,7 @@ button.ci-badge:hover {
   gap: 5px;
   height: 26px;
   background: transparent;
-  border: 1px solid #1f1f1f;
+  border: 1px solid var(--border);
   color: var(--text-secondary);
   font-size: 11.5px;
   font-weight: 500;
@@ -5872,11 +5872,11 @@ button.ci-badge:hover {
   white-space: nowrap;
 }
 .repo-action-btn:hover {
-  background: #161616;
+  background: var(--list-hover);
   color: var(--text-primary);
-  border-color: #2c2c2c;
+  border-color: var(--border-strong);
 }
-.repo-action-btn:active { background: #0e0e0e; }
+.repo-action-btn:active { background: var(--bg-app); }
 .repo-action-btn:focus-visible {
   outline: none;
   border-color: var(--raven-blue);
@@ -5941,7 +5941,7 @@ button.ci-badge:hover {
   height: 26px;
   padding: 0;
   background: var(--bg-elevated);
-  border: 1px solid #232323;
+  border: 1px solid var(--border);
   border-radius: 50%;
   cursor: pointer;
   overflow: hidden;
@@ -5989,7 +5989,7 @@ button.ci-badge:hover {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  border: 1px solid #232323;
+  border: 1px solid var(--border);
   display: block;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,6 +88,22 @@ body {
   background: var(--bg-app);
 }
 
+.status-bar {
+  height: 22px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 11px;
+  background: var(--accent);
+  color: #fff;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.status-item-end { margin-left: auto; }
+
 
 /* ── Tab Bar ─────────────────────────────────────────────── */
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9022,4 +9022,31 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .activity-more-menu{position:fixed;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.45);padding:4px;min-width:170px;z-index:200}
 .activity-more-item{display:flex;align-items:center;gap:9px;width:100%;padding:7px 10px;border-radius:5px;background:none;border:none;color:var(--text-primary);font-size:13px;font-family:var(--font-ui);cursor:pointer;text-align:left}
 .activity-more-item:hover{background:var(--list-hover)}
+
+/* ── Docked side panel ────────────────────────────────── */
+.side-panel{width:266px;flex-shrink:0;background:var(--bg-sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;min-height:0}
+.side-panel-head{display:flex;align-items:center;height:35px;padding:0 6px 0 16px;flex-shrink:0}
+.side-panel-head .ttl{font-size:11px;font-weight:600;letter-spacing:.09em;color:#bdbdbd;text-transform:uppercase}
+.side-panel-head .acts{margin-left:auto;display:flex;gap:1px}
+.side-panel-act{width:24px;height:24px;border-radius:5px;display:flex;align-items:center;justify-content:center;color:var(--text-muted);background:none;border:none;cursor:pointer}
+.side-panel-act:hover{background:var(--list-hover);color:var(--text-primary)}
+.side-panel-act svg{width:15px;height:15px}
+.side-panel-body{flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column}
+.repo-card{margin:2px 8px 8px;padding:9px 10px;background:#2024262e;border:1px solid var(--border);border-radius:7px}
+.repo-card-top{display:flex;align-items:center;gap:7px}
+.repo-card-top .gi{width:14px;height:14px;color:var(--text-secondary);flex-shrink:0}
+.repo-card-name{font-size:13px;font-weight:600;color:#e2e2e2;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.repo-card-ext{width:20px;height:20px;border-radius:4px;display:flex;align-items:center;justify-content:center;color:var(--text-muted);background:none;border:none;cursor:pointer}
+.repo-card-ext:hover{background:var(--list-hover);color:var(--text-primary)}
+.repo-card-ext svg{width:13px;height:13px}
+.repo-card-meta{display:flex;align-items:center;gap:8px;margin-top:7px}
+.branch-pill{display:inline-flex;align-items:center;gap:5px;font-family:var(--font-mono);font-size:11px;color:#cdd6f4;background:#0066ff1f;border:1px solid #0066ff33;padding:2px 8px;border-radius:11px}
+.branch-pill svg{width:11px;height:11px}
+.branch-pill.dirty{color:#f0c674;background:#f59e0b1a;border-color:#f59e0b33}
+.repo-sync{font-size:11px;color:var(--text-muted);display:flex;align-items:center;gap:4px}
+.repo-sync svg{width:11px;height:11px}
+.side-panel-link{margin:2px 8px 8px;display:flex;align-items:center;gap:7px;padding:9px 10px;border:1px dashed var(--border-strong);border-radius:7px;color:var(--text-secondary);font-size:13px;background:none;cursor:pointer;width:calc(100% - 16px)}
+.side-panel-link:hover{border-color:#0066ff66;color:#cdd6f4;background:#0066ff0d}
+.side-panel-body::-webkit-scrollbar{width:10px}
+.side-panel-body::-webkit-scrollbar-thumb{background:#4a4a4a;border-radius:6px;border:3px solid var(--bg-sidebar)}
 .activity-more-item svg{width:15px;height:15px;color:var(--text-secondary)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,7 +49,7 @@ html, body, #root {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
   background: var(--bg-app);
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
@@ -470,7 +470,7 @@ body {
 .sidebar-branch-badge {
   font-size: 9px;
   color: var(--text-muted);
-  font-family: 'SFMono-Regular', 'Consolas', monospace;
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1634,7 +1634,7 @@ body {
   font-size: 12px;
   line-height: 1.7;
   color: var(--text-secondary);
-  font-family: 'JetBrains Mono', 'Cascadia Code', monospace;
+  font-family: var(--font-mono);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -1921,7 +1921,7 @@ body {
 .pane-pid-chip {
   font-size: 9px;
   font-weight: 600;
-  font-family: 'SF Mono', 'Menlo', monospace;
+  font-family: var(--font-mono);
   letter-spacing: 0.4px;
   color: var(--raven-blue);
   background: #0066FF15;
@@ -2433,7 +2433,7 @@ body {
 
 /* Shared: branch label */
 .pr-branch {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
@@ -2524,7 +2524,7 @@ body {
 .pr-list-repo {
   font-size: 12px;
   color: var(--text-muted);
-  font-family: monospace;
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2778,7 +2778,7 @@ body {
 }
 
 .pr-file-name {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-primary);
   flex: 1;
@@ -2803,7 +2803,7 @@ body {
 .pr-diff-pre {
   margin: 0;
   padding: 6px 0;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   overflow-x: auto;
   background: var(--bg-surface);
@@ -3146,7 +3146,7 @@ body {
 
 .feed-repo {
   font-size: 12px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3300,7 +3300,7 @@ body {
 .block-card-time {
   font-size: 10px;
   color: var(--text-muted);
-  font-family: 'SF Mono', 'Menlo', monospace;
+  font-family: var(--font-mono);
 }
 
 .block-copy-btn {
@@ -3334,7 +3334,7 @@ body {
 .block-card-content {
   padding: 8px 10px;
   font-size: 11.5px;
-  font-family: 'SF Mono', 'Menlo', 'Cascadia Mono', 'Consolas', monospace;
+  font-family: var(--font-mono);
   line-height: 1.6;
   color: var(--text-secondary);
   white-space: pre-wrap;
@@ -4734,7 +4734,7 @@ kbd {
   border: 1px solid var(--border);
   border-radius: 5px;
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', 'Cascadia Code', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
   padding: 8px;
@@ -6330,7 +6330,7 @@ button.ci-badge:hover {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-primary);
   overflow: hidden;
@@ -6348,7 +6348,7 @@ button.ci-badge:hover {
 .rsp-sync {
   display: flex;
   gap: 6px;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   flex-shrink: 0;
 }
@@ -6373,7 +6373,7 @@ button.ci-badge:hover {
 .rsp-file-item:hover { background: rgba(255,255,255,0.04); }
 
 .rsp-file-status {
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 700;
   width: 12px;
@@ -6382,7 +6382,7 @@ button.ci-badge:hover {
 }
 
 .rsp-file-path {
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-secondary);
   overflow: hidden;
@@ -6437,7 +6437,7 @@ button.ci-badge:hover {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
 }
 
 .sp-header {
@@ -6570,7 +6570,7 @@ button.ci-badge:hover {
   border-radius: 5px;
   padding: 3px 10px;
   font-size: 12px;
-  font-family: 'Inter', monospace;
+  font-family: var(--font-mono);
   min-width: 70px;
   text-align: center;
 }
@@ -6713,7 +6713,7 @@ button.ci-badge:hover {
   border: 1px solid rgba(99,102,241,0.2);
   border-radius: 8px;
   padding: 12px;
-  font-family: 'Cascadia Mono', 'Consolas', monospace;
+  font-family: var(--font-mono);
 }
 
 /* ── User menu (sidebar avatar + popover) ─────────────────── */
@@ -7283,14 +7283,14 @@ button.ci-badge:hover {
 .wt-dot-gray { background: #555; }
 .wt-branch { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .wt-meta {
-  color: var(--text-muted); font-size: 9px; font-family: 'JetBrains Mono', monospace;
+  color: var(--text-muted); font-size: 9px; font-family: var(--font-mono);
 }
 .wt-empty { padding: 6px 12px; color: var(--text-muted); font-size: 11px; font-style: italic; }
 
 /* Slug: directory basename under the branch line. Muted, monospace so it
    reads as "this is where it lives on disk", not as content. */
 .wt-slug {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-muted);
   padding-left: 12px; /* visually nests under the branch text */
@@ -7300,7 +7300,7 @@ button.ci-badge:hover {
 /* +X / -Y diff chip — green/red tones tuned to read on the dark sidebar. */
 .wt-diff-chip {
   display: inline-flex; align-items: center; gap: 4px;
-  font-family: 'JetBrains Mono', monospace; font-size: 10px;
+  font-family: var(--font-mono); font-size: 10px;
   flex-shrink: 0;
 }
 .wt-diff-add { color: #4ade80; }
@@ -7315,7 +7315,7 @@ button.ci-badge:hover {
   border-radius: 4px;
   padding: 0 5px;
   font-size: 10px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   cursor: pointer;
   flex-shrink: 0;
   line-height: 1.4;
@@ -7338,7 +7338,7 @@ button.ci-badge:hover {
   width: 100%; box-sizing: border-box; background: var(--bg-elevated);
   border: 1px solid var(--border); border-radius: 4px;
   padding: 8px 10px; color: var(--text-primary);
-  font-size: 12px; font-family: 'JetBrains Mono', monospace;
+  font-size: 12px; font-family: var(--font-mono);
 }
 .field-input:focus { outline: none; border-color: var(--raven-blue); }
 .modal-error {
@@ -7365,7 +7365,7 @@ button.ci-badge:hover {
 .wt-env-banner-list {
   list-style: none;
   margin: 6px 0 0 22px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   color: #FFB800cc;
 }
@@ -7397,7 +7397,7 @@ button.ci-badge:hover {
   width: 100%; box-sizing: border-box; background: var(--bg-app);
   border: 1px solid var(--border); border-radius: 4px;
   padding: 10px 12px; color: var(--text-primary);
-  font-size: 14px; font-family: 'JetBrains Mono', monospace;
+  font-size: 14px; font-family: var(--font-mono);
 }
 .qw-input:focus { outline: none; border-color: var(--raven-blue); }
 .qw-hint { color: var(--text-muted); font-size: 10px; margin-top: 8px; }
@@ -7435,7 +7435,7 @@ button.ci-badge:hover {
 .preset-card-name { font-size: 12px; font-weight: 600; }
 .preset-card-desc {
   font-size: 11px; color: var(--text-secondary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
 }
 
@@ -7460,7 +7460,7 @@ button.ci-badge:hover {
 .preset-row-name { font-size: 12px; font-weight: 600; color: var(--text-primary); }
 .preset-row-id {
   font-size: 11px; color: var(--text-muted);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
 }
 .preset-row-desc { font-size: 11px; color: var(--text-secondary); }
 .preset-row-actions { display: flex; gap: 6px; }
@@ -7469,7 +7469,7 @@ button.ci-badge:hover {
   width: 100%; box-sizing: border-box; background: var(--bg-app);
   border: 1px solid var(--border); border-radius: 4px;
   padding: 8px 10px; color: var(--text-primary);
-  font-size: 11px; font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-family: var(--font-mono);
   resize: vertical; min-height: 200px;
 }
 .preset-editor-textarea:focus { outline: none; border-color: var(--raven-blue); }
@@ -7496,13 +7496,13 @@ button.ci-badge:hover {
 }
 .ports-group { display: flex; align-items: center; gap: 6px; }
 .ports-group-label {
-  color: var(--text-muted); font-family: 'JetBrains Mono', monospace;
+  color: var(--text-muted); font-family: var(--font-mono);
   white-space: nowrap;
 }
 .port-pill {
   background: var(--bg-elevated); border: 1px solid var(--border);
   border-radius: 4px; padding: 2px 8px;
-  color: var(--raven-blue); font-family: 'JetBrains Mono', monospace;
+  color: var(--raven-blue); font-family: var(--font-mono);
   font-size: 11px; cursor: pointer; transition: background 0.12s, border-color 0.12s;
 }
 .port-pill:hover {
@@ -7539,7 +7539,7 @@ button.ci-badge:hover {
   flex: 1; min-width: 0; background: var(--bg-elevated);
   border: 1px solid var(--border); border-radius: 3px;
   padding: 4px 8px; color: var(--text-primary);
-  font-size: 11px; font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-family: var(--font-mono);
 }
 .browser-url:focus { outline: none; border-color: var(--raven-blue); }
 .browser-placeholder {
@@ -7599,7 +7599,7 @@ button.ci-badge:hover {
   display: grid;
   grid-template-columns: 1.5fr 0.8fr 1fr 0.8fr 1fr 1fr 1fr;
   gap: 8px; padding: 6px 8px;
-  font-size: 11px; font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; font-family: var(--font-mono);
   background: var(--bg-elevated); border: 1px solid var(--border);
   border-radius: 4px; align-items: center;
 }
@@ -7653,7 +7653,7 @@ button.ci-badge:hover {
   width: 100%; background: transparent; border: 1px solid transparent;
   border-radius: 4px; padding: 6px 8px; cursor: pointer;
   color: var(--text-primary); font-size: 11px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   text-align: left;
 }
 .diff-file:hover { background: var(--bg-elevated); }
@@ -7664,7 +7664,7 @@ button.ci-badge:hover {
 .diff-del { color: #FF6666; }
 .diff-content {
   overflow: auto; padding: 8px 12px;
-  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  font-family: var(--font-mono); font-size: 11px;
 }
 .diff-hunk { margin-bottom: 12px; }
 .diff-hunk-header {
@@ -7694,7 +7694,7 @@ button.ci-badge:hover {
 }
 .ide-picker-item:hover { background: rgba(0, 102, 255, 0.10); }
 .ide-picker-name { font-size: 12px; font-weight: 500; }
-.ide-picker-path { font-size: 10px; color: var(--text-muted); font-family: 'JetBrains Mono', monospace; }
+.ide-picker-path { font-size: 10px; color: var(--text-muted); font-family: var(--font-mono); }
 .ide-picker-divider { height: 1px; background: var(--border); margin: 4px 0; }
 .ide-picker-redetect { color: var(--text-secondary); font-size: 11px; }
 
@@ -7728,7 +7728,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   border: 1px solid var(--border);
   color: var(--text-secondary);
   font-size: 12px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
   font-variant-numeric: tabular-nums;
   border-radius: 6px;
   padding: 4px 12px;
@@ -7872,7 +7872,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
 }
 
 .rb-divider {
@@ -7890,7 +7890,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 12px;
   padding: 4px 0;
   font-size: 12px;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
 }
 
 .rb-row--header {
@@ -8116,7 +8116,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .join-code-input {
   flex: 1;
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 16px;
   letter-spacing: 4px;
   text-align: center;
@@ -8177,7 +8177,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .team-join-code-value {
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 18px;
   font-weight: 700;
   color: var(--text-primary);
@@ -8257,7 +8257,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .browser-port-btn {
   font-weight: 700;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
 }
 
 .browser-port-dropdown {
@@ -8353,7 +8353,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .browser-port-num {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
   color: var(--raven-blue);
   font-weight: 600;
   font-size: 13px;
@@ -8395,7 +8395,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .rb-heavy-loc {
   color: #FFB800cc;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
 }
 
@@ -8414,7 +8414,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   border-radius: 4px;
   background: rgba(0, 102, 255, 0.12);
   color: var(--raven-blue);
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
   font-size: 10px;
   line-height: 1.4;
   font-variant-numeric: tabular-nums;
@@ -8495,7 +8495,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .rb-bucket-name {
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
   color: var(--text-secondary);
 }
 
@@ -8517,7 +8517,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   margin-left: 4px;
   color: var(--text-muted);
   font-size: 11px;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow: hidden;
@@ -8589,7 +8589,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: flex;
   flex-direction: column;
   gap: 12px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
   transition: border-color 150ms ease, background-color 150ms ease;
 }
 .tjcp-card:hover {
@@ -8636,7 +8636,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   border-radius: 8px;
 }
 .tjcp-code {
-  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 22px;
   font-weight: 700;
   letter-spacing: 0.18em;
@@ -8711,7 +8711,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .tjcp-primary-btn {
   height: 28px;
   padding: 0 14px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
   font-size: 12px;
   font-weight: 600;
   color: #fff;
@@ -8749,7 +8749,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: flex;
   flex-direction: column;
   gap: 14px;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-ui);
 }
 
 .jcf-subtitle {
@@ -8773,7 +8773,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   border: 1px solid var(--border, #1e1e1e);
   border-radius: 10px;
   color: var(--text-primary, #fff);
-  font-family: 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+  font-family: var(--font-mono);
   font-size: 24px;
   font-weight: 500;
   text-align: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6400,7 +6400,7 @@ button.ci-badge:hover {
   gap: 7px;
   padding: 3px 12px;
 }
-.rsp-file-item:hover { background: rgba(255,255,255,0.04); }
+.rsp-file-item:hover { background: var(--list-hover); }
 
 .rsp-file-status {
   font-family: var(--font-mono);
@@ -7298,7 +7298,7 @@ button.ci-badge:hover {
   padding: 6px 12px; cursor: pointer; font-size: 12px;
   color: var(--text-secondary);
 }
-.wt-item:hover { background: #111; color: var(--text-primary); }
+.wt-item:hover { background: var(--list-hover); color: var(--text-primary); }
 .wt-item-active {
   background: rgba(0, 102, 255, 0.10); color: var(--text-primary);
   border-left: 2px solid var(--raven-blue); padding-left: 10px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 export type AIType = 'claude' | 'gemini' | 'codex' | 'copilot' | 'opencode' | 'terminal' | 'custom' | 'browser'
 
+// Which docked side-panel section is open in the activity-bar sidebar (null = collapsed).
+export type PanelId = 'worktrees' | 'snippets' | 'mcp' | 'workspaces' | 'cmdhist'
+
 export interface Account {
   name: string
   aiType: AIType


### PR DESCRIPTION
## Summary

End-to-end UX restyle to bring the app in line with the **nestmux.com** design language: deep cool near-black surfaces, an emerald/cyan accent, and Inter + Geist Mono typography. Also reworks the left sidebar into a **labeled nav** with anchored popovers and an inline Worktrees accordion, and removes a pile of inconsistencies that made the app feel half-finished.

The single biggest fix: the codebase had **~80 leftover hardcoded blue literals** from before the accent was switched to emerald, so large parts of the app (Teams, command palette, presets, join terminal…) still rendered blue. The app is now a single coherent emerald theme.

## What changed

**Visual / theme**
- Re-based design tokens to nestmux's real captured values: layered near-black surfaces (oklch hue 240), 3-tier white-alpha borders, brighter text ramp.
- Bundled **Inter** (UI) + **Geist Mono** via `@fontsource` (offline-safe, no Google Fonts CDN).
- Unified **81 blue literals → emerald accent** (`#0066FF`/`rgba(0,102,255)`/`#0052cc` → `var(--accent)`/`oklch(...)`), preserving semantic git-event colors (`#3b82f6`).
- Motion tokens (`--ease`/`--dur`) + transitions on nav items, tabs, buttons; popover fade-in.
- Branded primary CTA (emerald + dark label), tighter hero typography, global `:focus-visible` ring.

**Structure**
- Labeled left **nav sidebar** (icon + label) replacing the icon-only activity bar.
- Snippets / MCP / Workspaces / Command History open **anchored popovers** (not a second docked panel) via a reusable `NavPopover` + `useFixedPopover`.
- **Worktrees** is an inline collapsible accordion (bounded + scrollable) — it's persistent working context, not a quick action.

**Housekeeping**
- All user-facing strings + code comments translated to **English** (app is English-only).
- Removed a corrupted dead-CSS line; gitignored dev-only preview screenshot dirs.

## Screenshots

> 📎 Matías: drag these from `.preview-shots/` into this description on GitHub:
> `01-initial.png`, `02-choose-ai.png`, `05-snippets.png`, `09-spotlight.png`, `10-teams-chat.png`, `11-teams-repos.png`

## Cross-platform testing — needs review on Mac/Linux 🙏

Authored + smoke-tested on **Windows only**. Please sanity-check on macOS/Linux:
- [ ] Window chrome / traffic-lights vs Windows controls in the titlebar
- [ ] Fonts render (Inter + Geist Mono bundled, no CDN) — terminal font is still platform-native
- [ ] Sidebar popovers anchor correctly to the right of the nav item, clamp to viewport
- [ ] Worktrees accordion scroll + overall layout density
- [ ] Emerald accent + near-black surfaces look right on Retina / different displays

## Tests & build

- `tsc --noEmit` clean, `npm run build` OK.
- Unit tests: **36 pass**; 2 pre-existing failures are Windows path-separator only (`worktree-store`, `worktree-integration`) — no new failures introduced.
- Preview/e2e harness (`RAVEN_E2E`) is gated in `electron/preload.ts`; **never active in production builds**.

## Notes

- Bundles the earlier `feat/ux-vscode-restyle` work (linear stack).
- Out of scope (pre-existing, tracked in CLAUDE.md): `profiles.github_token` plaintext + RLS hardening before public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
