### PR TITLE
feat(cli): instalar el CLI del agente desde el banner "CLI not found"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # 🪺 Nest by RAVEN
 
-**Multi-AI Terminal Workspace · v1.2.7**
+**Multi-AI Terminal Workspace · v1.3.1**
 
 Run Claude, Gemini, Codex, Copilot and more — side by side in a single window. Each pane is its own AI session, with its own account, history, and environment.
 
 [![Latest Release](https://img.shields.io/github/v/release/GeronimoDiClemente/raven-nest?style=flat-square&color=0066FF)](https://github.com/GeronimoDiClemente/raven-nest/releases/latest)
-[![v1.2.7](https://img.shields.io/badge/v1.2.7-current%20release-0066FF?style=flat-square)](#whats-new-in-v12)
+[![v1.3.1](https://img.shields.io/badge/v1.3.1-current%20release-0066FF?style=flat-square)](#whats-new-in-v13)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-lightgrey?style=flat-square)](https://github.com/GeronimoDiClemente/raven-nest/releases/latest)
 [![License: PolyForm Strict](https://img.shields.io/badge/license-PolyForm%20Strict%201.0.0-orange?style=flat-square)](./LICENSE)
 [![Source-available](https://img.shields.io/badge/source--available-official%20binaries%20only-orange?style=flat-square)](#license--redistribution)
@@ -22,7 +22,19 @@ Run Claude, Gemini, Codex, Copilot and more — side by side in a single window.
 
 Think of it as a terminal multiplexer — but built specifically for AI agents and the way teams ship code. Instead of juggling tabs and windows, you get a flexible **grid workspace** where every cell is an independent AI session, on top of the things developers actually need every day: native **git worktrees**, a real **Teams workspace**, your personal **My Repos** dashboard, GitHub & GitLab integration, CI runs, and live terminal sharing.
 
-> **v1.2 builds on the v1.1 foundation** with per-device repo paths, Teams crash fixes, and macOS bugfixes (credential persistence, port detection, auto-update). **v1.2.5 fixed the macOS auto-updater** — if you're on a version older than v1.2.5, download once manually; from v1.2.5 onwards `Install and restart` works automatically. **v1.2.6** restored terminal sessions after Cmd+Q. **v1.2.7** fixes port attribution for reparented background processes on macOS and Linux.
+> **v1.2 builds on the v1.1 foundation** with per-device repo paths, Teams crash fixes, and macOS bugfixes (credential persistence, port detection, auto-update). **v1.2.5 fixed the macOS auto-updater** — if you're on a version older than v1.2.5, download once manually; from v1.2.5 onwards `Install and restart` works automatically. **v1.2.6** restored terminal sessions after Cmd+Q. **v1.2.7** fixes port attribution for reparented background processes on macOS and Linux. **v1.3** adds an interactive onboarding tutorial, and **v1.3.1** lets you install an agent's CLI straight from the pane banner.
+
+---
+
+## What's new in v1.3
+
+### v1.3.1 — Install the agent CLI from the banner
+
+Open a pane for an AI whose CLI isn't installed yet and the **"CLI not found"** banner now shows a one-click **Install \<AI> CLI** button instead of a command to copy. Nest runs the install **in-app with a live log**, and **auto-opens the pane** the moment the CLI is ready. If the install fails — or finishes but the binary isn't on `PATH` — the banner falls back to the manual command so you're never stuck. When the CLI is already present, the banner never appears.
+
+### v1.3.0 — Interactive onboarding tutorial
+
+A guided onboarding that runs **on top of the real UI**, not a separate sandbox screen: **three narrated tours** — Worktrees, My Repos and Teams — with an illuminated spotlight that walks you through each core flow step by step. The Worktrees tour launches automatically on first run. This release also cleans up the sidebar worktree registry, dropping dead/stale worktree entries instead of leaving them lingering.
 
 ---
 
@@ -133,14 +145,14 @@ Versions up to and including **v1.0.1** were published under the Apache License 
 
 ## Download
 
-Latest: **v1.2.7** — port attribution for reparented background processes, terminal session fix after Cmd+Q, auto-update fix (on top of v1.2.0 per-device paths + v1.1.x tiling layout + port detection + security hardening).
+Latest: **v1.3.1** — install an agent's CLI straight from the pane banner, on top of v1.3.0's interactive onboarding tutorial (3 guided tours) and the v1.2.x port-attribution, session and auto-update fixes.
 
 | Platform | Download |
 |----------|----------|
-| **macOS** (Apple Silicon) | [Nest-1.2.7-arm64.dmg](../../releases/latest) |
-| **Windows** | [Nest-Setup-1.2.7.exe](../../releases/latest) |
-| **Linux** (universal) | [Nest-1.2.7.AppImage](../../releases/latest) |
-| **Linux** (Debian / Ubuntu) | [nest_1.2.7_amd64.deb](../../releases/latest) |
+| **macOS** (Apple Silicon) | [Nest-1.3.1-arm64.dmg](../../releases/latest) |
+| **Windows** | [Nest-Setup-1.3.1.exe](../../releases/latest) |
+| **Linux** (universal) | [Nest-1.3.1.AppImage](../../releases/latest) |
+| **Linux** (Debian / Ubuntu) | [nest_1.3.1_amd64.deb](../../releases/latest) |
 
 > Nest auto-updates in the background. **If you're upgrading from a version older than v1.2.5, this first download is manual** — the auto-updater was broken on macOS before v1.2.5. After installing v1.2.5 or later, future updates install automatically via `Install and restart`.
 
@@ -161,8 +173,8 @@ Two formats, pick whichever fits your distro.
 Works on Ubuntu, Fedora, Arch, openSUSE, Mint, Pop!_OS and most others. No system-wide install.
 
 ```bash
-chmod +x ~/Downloads/Nest-1.2.7.AppImage
-~/Downloads/Nest-1.2.7.AppImage
+chmod +x ~/Downloads/Nest-1.3.1.AppImage
+~/Downloads/Nest-1.3.1.AppImage
 ```
 
 To integrate it into your apps menu, use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) or move it to `~/Applications/`.
@@ -172,7 +184,7 @@ To integrate it into your apps menu, use [AppImageLauncher](https://github.com/T
 Installs system-wide, registers the desktop entry and the `nest://` deep link handler.
 
 ```bash
-sudo apt install ~/Downloads/nest_1.2.7_amd64.deb
+sudo apt install ~/Downloads/nest_1.3.1_amd64.deb
 ```
 
 Required packages (auto-installed by `apt`): `libgtk-3-0`, `libnotify4`, `libnss3`, `libxss1`, `libxtst6`, `libatspi2.0-0`, `libdrm2`, `libgbm1`, `libxcb-dri3-0`, `xdg-utils`.

--- a/electron/__tests__/cli-install-runner.test.ts
+++ b/electron/__tests__/cli-install-runner.test.ts
@@ -50,6 +50,13 @@ describe('CliInstallRunner', () => {
     expect(result.state).toBe('cancelled')
   }, 10000)
 
+  it('timeout → state failed with timed out in log', async () => {
+    const slow = process.platform === 'win32' ? 'ping -n 30 127.0.0.1' : 'sleep 30'
+    const result = await runner.run('test', slow, () => {}, { timeoutMs: 200 })
+    expect(result.state).toBe('failed')
+    expect(result.log).toContain('timed out')
+  }, 10000)
+
   it('INSTALL_COMMANDS covers the five known AIs', () => {
     expect(Object.keys(INSTALL_COMMANDS).sort()).toEqual(
       ['claude', 'codex', 'copilot', 'gemini', 'opencode'],

--- a/electron/__tests__/cli-install-runner.test.ts
+++ b/electron/__tests__/cli-install-runner.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CliInstallRunner, INSTALL_COMMANDS } from '../cli-install-runner'
+
+describe('CliInstallRunner', () => {
+  let runner: CliInstallRunner
+
+  beforeEach(() => {
+    runner = new CliInstallRunner()
+  })
+
+  it('resolves done and streams output for a successful command', async () => {
+    const lines: string[] = []
+    const result = await runner.run('test', 'echo hello', (l) => lines.push(l))
+    expect(result.state).toBe('done')
+    expect(result.log).toContain('hello')
+    expect(lines.some((l) => l.includes('hello'))).toBe(true)
+  })
+
+  it('non-zero exit → failed', async () => {
+    const cmd = process.platform === 'win32' ? 'cmd /c exit 1' : 'sh -c "exit 1"'
+    const result = await runner.run('test', cmd, () => {})
+    expect(result.state).toBe('failed')
+  })
+
+  it('spawn error → failed (does not hang)', async () => {
+    const result = await runner.run('test', 'definitely-not-a-real-binary-xyz', () => {})
+    expect(result.state).toBe('failed')
+  })
+
+  it('redacts secret-like values in the log', async () => {
+    const result = await runner.run('test', 'echo TOKEN=abc123secret', () => {})
+    expect(result.log).toContain('<redacted>')
+    expect(result.log).not.toContain('abc123secret')
+  })
+
+  it('rejects a second run with the same key', async () => {
+    const slow = process.platform === 'win32' ? 'ping -n 3 127.0.0.1' : 'sleep 1'
+    const p = runner.run('test', slow, () => {})
+    await expect(runner.run('test', 'echo x', () => {})).rejects.toThrow(/already running/)
+    runner.cancel('test')
+    await p
+  })
+
+  it('cancel() stops mid-run with state cancelled', async () => {
+    const slow = process.platform === 'win32' ? 'ping -n 30 127.0.0.1' : 'sleep 30'
+    const p = runner.run('test', slow, () => {})
+    await new Promise((r) => setTimeout(r, 100))
+    expect(runner.cancel('test')).toBe(true)
+    const result = await p
+    expect(result.state).toBe('cancelled')
+  }, 10000)
+
+  it('INSTALL_COMMANDS covers the five known AIs', () => {
+    expect(Object.keys(INSTALL_COMMANDS).sort()).toEqual(
+      ['claude', 'codex', 'copilot', 'gemini', 'opencode'],
+    )
+  })
+})

--- a/electron/cli-install-runner.ts
+++ b/electron/cli-install-runner.ts
@@ -1,0 +1,136 @@
+import { spawn, type ChildProcess } from 'child_process'
+
+export type InstallState = 'done' | 'failed' | 'cancelled'
+
+/**
+ * Allowlist of install commands keyed by AIType string. The renderer passes
+ * only the aiType; the main process resolves the command here so the renderer
+ * can never hand an arbitrary shell string to the spawner.
+ */
+export const INSTALL_COMMANDS: Record<string, string> = {
+  claude:   'npm install -g @anthropic-ai/claude-code',
+  gemini:   'npm install -g @google/gemini-cli',
+  codex:    'npm install -g @openai/codex',
+  copilot:  'gh extension install github/gh-copilot',
+  opencode: 'npm install -g opencode',
+}
+
+const SECRET_RE = /(?:^|[\s=:])(?:token|key|password|secret|api[_-]?key)\s*[=:]\s*\S+/gi
+
+function redact(line: string): string {
+  return line.replace(SECRET_RE, (m) => m.replace(/[=:]\s*\S+/, (kv) => kv.replace(/\S+$/, '<redacted>')))
+}
+
+function isWindows(): boolean {
+  return process.platform === 'win32'
+}
+
+const DEFAULT_TIMEOUT_MS = 180_000
+
+interface ActiveRun {
+  child: ChildProcess | null
+  cancelled: boolean
+}
+
+export interface RunOpts {
+  env?: NodeJS.ProcessEnv
+  timeoutMs?: number
+}
+
+export class CliInstallRunner {
+  private active = new Map<string, ActiveRun>()
+
+  run(
+    key: string,
+    cmd: string,
+    onProgress: (line: string) => void,
+    opts: RunOpts = {},
+  ): Promise<{ state: InstallState; log: string }> {
+    if (this.active.has(key)) {
+      return Promise.reject(new Error(`install already running for ${key}`))
+    }
+    const env = opts.env ?? process.env
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+    return new Promise((resolve) => {
+      const log: string[] = []
+      const slot: ActiveRun = { child: null, cancelled: false }
+      this.active.set(key, slot)
+
+      let finished = false
+      const finish = (state: InstallState) => {
+        if (finished) return
+        finished = true
+        this.active.delete(key)
+        resolve({ state, log: log.join('\n') })
+      }
+
+      const push = (chunk: string) => {
+        for (const line of chunk.split(/\r?\n/)) {
+          if (!line) continue
+          const safe = redact(line)
+          log.push(safe)
+          onProgress(safe)
+        }
+      }
+
+      push(`$ ${cmd}`)
+
+      const child = isWindows()
+        ? spawn(cmd, { env, shell: true })
+        : spawn('/bin/sh', ['-c', cmd], { env })
+      slot.child = child
+
+      let timedOut = false
+      const timer = setTimeout(() => {
+        timedOut = true
+        push(`error: install timed out after ${Math.round(timeoutMs / 1000)}s — killing`)
+        try {
+          if (isWindows()) {
+            const pid = child.pid
+            if (pid) spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' })
+          } else {
+            child.kill('SIGTERM')
+          }
+        } catch {}
+      }, timeoutMs)
+
+      child.stdout?.on('data', (d) => push(d.toString('utf8')))
+      child.stderr?.on('data', (d) => push(d.toString('utf8')))
+      child.on('error', (err) => {
+        clearTimeout(timer)
+        push(`error: ${err.message}`)
+        finish(slot.cancelled ? 'cancelled' : 'failed')
+      })
+      child.on('exit', (code, signal) => {
+        clearTimeout(timer)
+        if (slot.cancelled) return finish('cancelled')
+        if (timedOut) return finish('failed')
+        if (code === 0) return finish('done')
+        push(`exited with code ${code ?? 'null'}${signal ? ' signal ' + signal : ''}`)
+        finish('failed')
+      })
+    })
+  }
+
+  cancel(key: string): boolean {
+    const slot = this.active.get(key)
+    if (!slot) return false
+    slot.cancelled = true
+    const child = slot.child
+    if (!child) return true
+    if (isWindows()) {
+      try {
+        const pid = child.pid
+        if (pid) spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' })
+      } catch {}
+    } else {
+      try { child.kill('SIGTERM') } catch {}
+    }
+    return true
+  }
+
+  cancelAll(): void {
+    for (const key of Array.from(this.active.keys())) this.cancel(key)
+  }
+}

--- a/electron/cli-install-runner.ts
+++ b/electron/cli-install-runner.ts
@@ -12,7 +12,7 @@ export const INSTALL_COMMANDS: Record<string, string> = {
   gemini:   'npm install -g @google/gemini-cli',
   codex:    'npm install -g @openai/codex',
   copilot:  'gh extension install github/gh-copilot',
-  opencode: 'npm install -g opencode',
+  opencode: 'npm install -g opencode-ai',
 }
 
 const SECRET_RE = /(?:^|[\s=:])(?:token|key|password|secret|api[_-]?key)\s*[=:]\s*\S+/gi

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -848,7 +848,7 @@ ipcMain.handle('cli:install', async (event, aiType: string) => {
   return cliInstallRunner.run(
     aiType,
     cmd,
-    (line) => event.sender.send('cli:install:progress', { aiType, line }),
+    (line) => { try { event.sender.send('cli:install:progress', { aiType, line }) } catch { /* renderer gone */ } },
     { env: { ...process.env, PATH: cliLookupPath() } },
   )
 })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -112,6 +112,7 @@ import { WorkspaceStore } from './workspace-store'
 import { WorktreeStore } from './worktree-store'
 import { PresetStore } from './preset-store'
 import { SetupRunner } from './setup-runner'
+import { CliInstallRunner, INSTALL_COMMANDS } from './cli-install-runner'
 import { scanPid } from './port-monitor'
 import { getCwdForPid, getProcessInfo, listListeningPidsPosix, listListeningPidsWindows } from './cwd-reader'
 // pidtree resolves a pid's full descendant tree. Used so port scans cover the
@@ -145,6 +146,7 @@ const workspaceStore = new WorkspaceStore()
 const worktreeStore = new WorktreeStore(pathJoin(ravenHome(), '.raven-nest'))
 const presetStore = new PresetStore()
 const setupRunner = new SetupRunner()
+const cliInstallRunner = new CliInstallRunner()
 const browserPanes = new BrowserPaneManager(() => BrowserWindow.getAllWindows()[0] ?? null)
 const spotlight = new SpotlightEngine()
 const benchmark = new BenchmarkRecorder()
@@ -839,6 +841,19 @@ ipcMain.handle('cli:check', (_event, cmd: string) => {
     return { found: false, path: '' }
   }
 })
+
+ipcMain.handle('cli:install', async (event, aiType: string) => {
+  const cmd = INSTALL_COMMANDS[aiType]
+  if (!cmd) return { state: 'failed' as const, log: `No install command for "${aiType}"` }
+  return cliInstallRunner.run(
+    aiType,
+    cmd,
+    (line) => event.sender.send('cli:install:progress', { aiType, line }),
+    { env: { ...process.env, PATH: cliLookupPath() } },
+  )
+})
+
+ipcMain.handle('cli:install:cancel', (_event, aiType: string) => cliInstallRunner.cancel(aiType))
 
 // Custom CLI IPC handlers
 ipcMain.handle('customcli:list', () => customCLIStore.list())
@@ -2334,6 +2349,7 @@ app.on('before-quit', () => {
   // `npm install` spawn many sub-processes) cleanly instead of orphaning
   // them for a moment.
   setupRunner.cancelAll()
+  cliInstallRunner.cancelAll()
   // Stop the spotlight fs.watch handle. The watcher keeps the event loop
   // alive on macOS/Linux and would block app exit otherwise.
   void spotlight.stop()

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -152,6 +152,13 @@ contextBridge.exposeInMainWorld('pathUtils', {
 
 contextBridge.exposeInMainWorld('cli', {
   check: (cmd: string) => ipcRenderer.invoke('cli:check', cmd),
+  install: (aiType: string) => ipcRenderer.invoke('cli:install', aiType),
+  cancelInstall: (aiType: string) => ipcRenderer.invoke('cli:install:cancel', aiType),
+  onInstallProgress: (cb: (data: { aiType: string; line: string }) => void) => {
+    const handler = (_event: unknown, data: { aiType: string; line: string }) => cb(data)
+    ipcRenderer.on('cli:install:progress', handler)
+    return () => ipcRenderer.removeListener('cli:install:progress', handler)
+  },
 })
 
 contextBridge.exposeInMainWorld('shells', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Nest by RAVEN — Multi-AI Terminal Multiplexer",
   "engines": {
     "node": ">=20.19"

--- a/src/components/NewPaneDialog.tsx
+++ b/src/components/NewPaneDialog.tsx
@@ -86,6 +86,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
   const [installReason, setInstallReason] = useState<'failed' | 'not-on-path'>('failed')
   const [installLog, setInstallLog] = useState('')
   const logRef = useRef<HTMLDivElement>(null)
+  const installAbortRef = useRef(false)
   const [shells, setShells] = useState<ShellInfo[]>([])
   const [shellsError, setShellsError] = useState<string | null>(null)
   const isWindows = window.platform?.isWin ?? false
@@ -128,6 +129,8 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
   }, [installLog])
 
+  useEffect(() => () => { installAbortRef.current = true }, [])
+
   async function selectAI(aiType: AIType) {
     const cfg = AI_CONFIG[aiType]
     setSelectedAI(aiType)
@@ -169,6 +172,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
   async function installCli() {
     if (!selectedAI) return
     const ai = selectedAI
+    installAbortRef.current = false
     setInstallLog('')
     setInstallState('installing')
     const unsub = window.cli.onInstallProgress(({ aiType, line }) => {
@@ -187,6 +191,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
     if (!found) { setInstallReason('not-on-path'); setInstallState('error'); return }
     setInstallState('done')
     setTimeout(() => {
+      if (installAbortRef.current) return
       const cfg = AI_CONFIG[ai]
       if (cfg.noAccount) {
         onConfirm(ai, 'default', '', cfg.color, cfg.cmd)
@@ -384,7 +389,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
           </>
         ) : (
           <>
-            <button className="dialog-back" onClick={() => { setStep('select-ai'); setCliFound(null) }}>← Back</button>
+            <button className="dialog-back" onClick={() => { installAbortRef.current = true; setStep('select-ai'); setCliFound(null) }}>← Back</button>
             <h2 className="dialog-title">
               <span style={{ color: AI_CONFIG[selectedAI!].color }}>{AI_CONFIG[selectedAI!].label}</span>
               {' '}Account

--- a/src/components/NewPaneDialog.tsx
+++ b/src/components/NewPaneDialog.tsx
@@ -404,16 +404,7 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
                     {copied ? '✓' : 'Copy'}
                   </button>
                   <button
-                    style={{
-                      background: 'transparent',
-                      color: '#888',
-                      border: '1px solid #333',
-                      borderRadius: 4,
-                      padding: '4px 10px',
-                      fontSize: 11,
-                      cursor: 'pointer',
-                      flexShrink: 0,
-                    }}
+                    className="cli-banner-link"
                     onClick={() => window.electronShell.openExternal(CLI_INSTALL[selectedAI!]!.url)}
                   >
                     Docs ↗

--- a/src/components/NewPaneDialog.tsx
+++ b/src/components/NewPaneDialog.tsx
@@ -10,7 +10,7 @@ const CLI_INSTALL: Partial<Record<AIType, { cmd: string; url: string }>> = {
   gemini:   { cmd: 'npm install -g @google/gemini-cli',        url: 'https://github.com/google-gemini/gemini-cli' },
   codex:    { cmd: 'npm install -g @openai/codex',             url: 'https://github.com/openai/codex' },
   copilot:  { cmd: 'gh extension install github/gh-copilot',   url: 'https://docs.github.com/en/copilot/github-copilot-in-the-cli' },
-  opencode: { cmd: 'npm install -g opencode',                   url: 'https://opencode.ai' },
+  opencode: { cmd: 'npm install -g opencode-ai',                url: 'https://opencode.ai' },
 }
 
 type LogoComponent = React.FC<{ size?: number; color?: string }>

--- a/src/components/NewPaneDialog.tsx
+++ b/src/components/NewPaneDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { AIType, AI_CONFIG, COLOR_PALETTE, CustomCLI, ShellInfo } from '../types'
 import { safeWriteText } from '../lib/clipboard'
 import { ClaudeLogo, GeminiLogo, CodexLogo, CopilotLogo, OpenCodeLogo } from './AILogos'
@@ -82,6 +82,10 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
   const [confirmDelete, setConfirmDelete] = useState<{ type: 'account'; name: string } | { type: 'cli'; id: string; label: string; e: React.MouseEvent } | null>(null)
   const [cliFound, setCliFound] = useState<boolean | null>(null)
   const [copied, setCopied] = useState(false)
+  const [installState, setInstallState] = useState<'idle' | 'installing' | 'done' | 'error'>('idle')
+  const [installReason, setInstallReason] = useState<'failed' | 'not-on-path'>('failed')
+  const [installLog, setInstallLog] = useState('')
+  const logRef = useRef<HTMLDivElement>(null)
   const [shells, setShells] = useState<ShellInfo[]>([])
   const [shellsError, setShellsError] = useState<string | null>(null)
   const isWindows = window.platform?.isWin ?? false
@@ -115,8 +119,14 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
     const cmd = AI_CONFIG[selectedAI].cmd
     if (!cmd) { setCliFound(true); return }
     setCliFound(null)
+    setInstallState('idle')
+    setInstallLog('')
     window.cli.check(cmd).then(r => setCliFound(r.found))
   }, [step, selectedAI])
+
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [installLog])
 
   async function selectAI(aiType: AIType) {
     const cfg = AI_CONFIG[aiType]
@@ -154,6 +164,37 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
     if (!selectedAI) return
     const dir = await window.accounts.getDir(selectedAI, name)
     onConfirm(selectedAI, name, dir, borderColor, AI_CONFIG[selectedAI].cmd)
+  }
+
+  async function installCli() {
+    if (!selectedAI) return
+    const ai = selectedAI
+    setInstallLog('')
+    setInstallState('installing')
+    const unsub = window.cli.onInstallProgress(({ aiType, line }) => {
+      if (aiType === ai) setInstallLog((prev) => (prev ? `${prev}\n${line}` : line))
+    })
+    let result: { state: 'done' | 'failed' | 'cancelled'; log: string }
+    try {
+      result = await window.cli.install(ai)
+    } finally {
+      unsub()
+    }
+    if (result.state === 'cancelled') { setInstallState('idle'); return }
+    if (result.state === 'failed') { setInstallReason('failed'); setInstallState('error'); return }
+    // done → re-check that the binary is now on PATH
+    const { found } = await window.cli.check(AI_CONFIG[ai].cmd)
+    if (!found) { setInstallReason('not-on-path'); setInstallState('error'); return }
+    setInstallState('done')
+    setTimeout(() => {
+      const cfg = AI_CONFIG[ai]
+      if (cfg.noAccount) {
+        onConfirm(ai, 'default', '', cfg.color, cfg.cmd)
+      } else {
+        setCliFound(true)
+        setInstallState('idle')
+      }
+    }, 900)
   }
 
   async function createAccount() {
@@ -352,69 +393,153 @@ export default function NewPaneDialog({ onConfirm, onCancel, allowedAIs, onUpgra
             {/* CLI detection banner */}
             {cliFound === false && selectedAI && CLI_INSTALL[selectedAI] && (
               <div style={{
-                background: '#2a1a00',
-                border: '1px solid #f59e0b',
+                background:
+                  installState === 'done' || (installState === 'error' && installReason === 'not-on-path')
+                    ? '#07210f'
+                    : installState === 'error'
+                      ? '#2a0a0a'
+                      : '#2a1a00',
+                border: `1px solid ${
+                  installState === 'done' || (installState === 'error' && installReason === 'not-on-path')
+                    ? '#22c55e'
+                    : installState === 'error'
+                      ? '#ef4444'
+                      : '#f59e0b'
+                }`,
                 borderRadius: 6,
                 padding: '10px 12px',
                 marginBottom: 12,
                 fontSize: 11,
               }}>
-                <div style={{ color: '#f59e0b', fontWeight: 600, marginBottom: 6 }}>
-                  ⚠ {AI_CONFIG[selectedAI].label} CLI not found
-                </div>
-                <div style={{ color: '#aaa', marginBottom: 8 }}>
-                  Install it with:
-                </div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <code style={{
-                    flex: 1,
-                    background: '#111',
-                    border: '1px solid #333',
-                    borderRadius: 4,
-                    padding: '4px 8px',
-                    color: '#e2e8f0',
-                    fontSize: 11,
-                    fontFamily: 'monospace',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}>
-                    {CLI_INSTALL[selectedAI]!.cmd}
-                  </code>
-                  <button
-                    style={{
-                      background: copied ? '#22c55e' : '#333',
-                      color: '#fff',
-                      border: 'none',
-                      borderRadius: 4,
-                      padding: '4px 10px',
-                      fontSize: 11,
-                      cursor: 'pointer',
-                      flexShrink: 0,
-                    }}
-                    onClick={() => {
-                      void safeWriteText(CLI_INSTALL[selectedAI!]!.cmd).then(ok => {
-                        if (ok) {
-                          setCopied(true)
-                          setTimeout(() => setCopied(false), 2000)
-                        }
-                      })
-                    }}
-                  >
-                    {copied ? '✓' : 'Copy'}
-                  </button>
-                  <button
-                    className="cli-banner-link"
-                    onClick={() => window.electronShell.openExternal(CLI_INSTALL[selectedAI!]!.url)}
-                  >
-                    Docs ↗
-                  </button>
-                </div>
+                {installState === 'idle' && (
+                  <>
+                    <div style={{ color: '#f59e0b', fontWeight: 600, marginBottom: 6 }}>
+                      ⚠ {AI_CONFIG[selectedAI].label} CLI not found
+                    </div>
+                    <div style={{ color: '#aaa', marginBottom: 8 }}>
+                      Raven Nest can install it for you.
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <button className="cli-banner-install" onClick={installCli}>
+                        Install {AI_CONFIG[selectedAI].label} CLI
+                      </button>
+                      <button
+                        className="cli-banner-link"
+                        onClick={() => window.electronShell.openExternal(CLI_INSTALL[selectedAI!]!.url)}
+                      >
+                        Docs ↗
+                      </button>
+                    </div>
+                  </>
+                )}
+
+                {installState === 'installing' && (
+                  <>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+                      <span className="cli-banner-spinner" />
+                      <div style={{ color: '#f59e0b', fontWeight: 600, flex: 1 }}>
+                        Installing {AI_CONFIG[selectedAI].label} CLI…
+                      </div>
+                      <button
+                        style={{ background: 'transparent', color: '#888', border: '1px solid #333', borderRadius: 4, padding: '4px 10px', fontSize: 11, cursor: 'pointer', flexShrink: 0 }}
+                        onClick={() => window.cli.cancelInstall(selectedAI!)}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                    <div className="cli-banner-log" ref={logRef}>{installLog}</div>
+                  </>
+                )}
+
+                {installState === 'done' && (
+                  <>
+                    <div style={{ color: '#22c55e', fontWeight: 600, marginBottom: 4 }}>
+                      ✓ {AI_CONFIG[selectedAI].label} CLI installed
+                    </div>
+                    <div style={{ color: '#aaa' }}>Opening {AI_CONFIG[selectedAI].label}…</div>
+                  </>
+                )}
+
+                {installState === 'error' && installReason === 'not-on-path' && (
+                  <>
+                    <div style={{ color: '#22c55e', fontWeight: 600, marginBottom: 6 }}>
+                      ✓ {AI_CONFIG[selectedAI].label} CLI installed
+                    </div>
+                    <div style={{ color: '#aaa', marginBottom: 8 }}>
+                      Restart Raven Nest to pick it up.
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <button
+                        className="cli-banner-link"
+                        onClick={() => window.electronShell.openExternal(CLI_INSTALL[selectedAI!]!.url)}
+                      >
+                        Docs ↗
+                      </button>
+                    </div>
+                  </>
+                )}
+
+                {installState === 'error' && installReason === 'failed' && (
+                  <>
+                    <div style={{ color: '#ef4444', fontWeight: 600, marginBottom: 6 }}>
+                      ✗ Install failed
+                    </div>
+                    <div style={{ color: '#aaa', marginBottom: 8 }}>
+                      Try it manually:
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                      <code style={{
+                        flex: 1,
+                        background: '#111',
+                        border: '1px solid #333',
+                        borderRadius: 4,
+                        padding: '4px 8px',
+                        color: '#e2e8f0',
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}>
+                        {CLI_INSTALL[selectedAI]!.cmd}
+                      </code>
+                      <button
+                        style={{
+                          background: copied ? '#22c55e' : '#333',
+                          color: '#fff',
+                          border: 'none',
+                          borderRadius: 4,
+                          padding: '4px 10px',
+                          fontSize: 11,
+                          cursor: 'pointer',
+                          flexShrink: 0,
+                        }}
+                        onClick={() => {
+                          void safeWriteText(CLI_INSTALL[selectedAI!]!.cmd).then(ok => {
+                            if (ok) {
+                              setCopied(true)
+                              setTimeout(() => setCopied(false), 2000)
+                            }
+                          })
+                        }}
+                      >
+                        {copied ? '✓' : 'Copy'}
+                      </button>
+                      <button
+                        className="cli-banner-link"
+                        onClick={() => window.electronShell.openExternal(CLI_INSTALL[selectedAI!]!.url)}
+                      >
+                        Docs ↗
+                      </button>
+                    </div>
+                    {installLog && <div className="cli-banner-log" ref={logRef}>{installLog}</div>}
+                  </>
+                )}
               </div>
             )}
 
             {/* noAccount types (opencode) land here only when CLI not found — show open anyway */}
-            {selectedAI && AI_CONFIG[selectedAI].noAccount && cliFound === false && (
+            {selectedAI && AI_CONFIG[selectedAI].noAccount && cliFound === false && installState === 'idle' && (
               <button
                 className="btn-primary"
                 style={{ width: '100%', marginBottom: 8 }}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4134,6 +4134,25 @@ kbd {
   color: var(--text-primary);
 }
 
+/* ── CLI-not-found banner: "Docs ↗" link button ───────────── */
+.cli-banner-link {
+  background: transparent;
+  color: #cbd5e1;
+  border: 1px solid #475569;
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.cli-banner-link:hover {
+  background: #1e293b;
+  border-color: #64748b;
+  color: #fff;
+}
+
 /* ── AI Grid ─────────────────────────────────────────────── */
 
 .ai-grid {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4153,6 +4153,53 @@ kbd {
   color: #fff;
 }
 
+.cli-banner-install {
+  background: #f59e0b;
+  color: #1a1200;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: filter 0.15s;
+}
+
+.cli-banner-install:hover {
+  filter: brightness(1.08);
+}
+
+.cli-banner-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #f59e0b;
+  border-top-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+  animation: cli-spin 0.8s linear infinite;
+}
+
+@keyframes cli-spin {
+  to { transform: rotate(360deg); }
+}
+
+.cli-banner-log {
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin-top: 8px;
+  color: #e2e8f0;
+  font-size: 10.5px;
+  font-family: monospace;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  max-height: 140px;
+  overflow-y: auto;
+}
+
 /* ── AI Grid ─────────────────────────────────────────────── */
 
 .ai-grid {

--- a/src/types.ts
+++ b/src/types.ts
@@ -438,6 +438,9 @@ declare global {
     }
     cli: {
       check: (cmd: string) => Promise<{ found: boolean; path: string }>
+      install: (aiType: string) => Promise<{ state: 'done' | 'failed' | 'cancelled'; log: string }>
+      cancelInstall: (aiType: string) => Promise<boolean>
+      onInstallProgress: (cb: (data: { aiType: string; line: string }) => void) => () => void
     }
     shells: {
       detect: () => Promise<ShellInfo[]>


### PR DESCRIPTION
@
## Resumen

Reemplaza el "copiá este comando" del banner **CLI not found** (`NewPaneDialog`) por un botón **Install <AI> CLI** que instala el CLI del agente desde la app, con log en vivo, y abre el panel al terminar.

- **Backend** `electron/cli-install-runner.ts` (nuevo): `CliInstallRunner` (spawn + stream + cancel + timeout + redacción de secretos) y allowlist `INSTALL_COMMANDS` por `aiType`. El renderer **solo** manda el `aiType`; el comando se resuelve en el main (nunca un comando arbitrario cruza el IPC).
- **IPC** `cli:install` / `cli:install:cancel` + `cancelAll()` en quit; bridge `window.cli.{install,cancelInstall,onInstallProgress}` en preload + tipos.
- **UI**: banner con 4 estados — `idle` (Install + Docs) · `installing` (spinner + log npm en vivo + Cancel) · `done` (verde, abre el panel) · `error` (`failed` → fallback al comando+Copy+Docs · `not-on-path` → "reiniciá Raven Nest"). Auto-open con guard si se navega Back/cierra el diálogo.

9 commits (incluye 2 fixes de code review: try/catch en el progress send contra webContents destruido, y guard del auto-open de 900ms).

## Verificación

- [x] `npm test` — **125/125** (incluye 8 tests nuevos del runner: éxito, exit≠0, error de spawn, redacción, doble-run, cancel, timeout, allowlist)
- [x] `npm run build` (electron-vite) — OK
- [x] Final integration review — contratos IPC consistentes en las 3 capas, los 5 `aiType` ↔ `INSTALL_COMMANDS` alineados, allowlist de seguridad respetada
- [ ] **Smoke manual GUI** (pendiente, lo reviso el finde): `npm run dev` → New Pane → AI sin CLI → Install (log/cancel) + caso falla + caso OK

## Notas

- `tsc -b` arrastra **19 errores preexistentes ajenos a este PR** (deuda de `main`); este feature agrega **0**. El build de prod no los toca (electron-vite usa esbuild). Limpieza aparte.
- `copilot`: el re-check valida que `gh` existe, no la extensión `gh copilot` (conservador, ya en limitaciones conocidas del plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@