### PR TITLE
feat(team-stats): dashboard de analytics del equipo para líderes

### DIFF
--- a/docs/superpowers/plans/2026-07-08-team-analytics.md
+++ b/docs/superpowers/plans/2026-07-08-team-analytics.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Un nuevo hook `useTeamStats` fetcha los eventos de GitHub (mismo endpoint que usa `ActivityFeed`) y los agrega por `actor.login`. Un componente `TeamStats` renderiza overview cards + tabla de developers. `TeamsWorkspace` recibe el nuevo tab `'stats'` con mínimos cambios: una línea en el tipo, una entrada en `NAV_ITEMS` y un bloque de render.
 
-**Tech Stack:** React + TypeScript, Vitest + @testing-library/react, GitHub REST API (`/repos/:owner/:repo/events`), Supabase Realtime (presence ya existente).
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react, Playwright (e2e Electron), GitHub REST API (`/repos/:owner/:repo/events`), Supabase Realtime (presence ya existente).
 
 ## Global Constraints
 
@@ -29,6 +29,17 @@
 | `src/__tests__/components/TeamStats.test.tsx` | Crear | Tests del componente |
 | `src/styles/global.css` | Modificar | Agregar clases `.ts-*` al final del archivo |
 | `src/components/TeamsWorkspace.tsx` | Modificar | Agregar `'stats'` al tipo, nav item y render |
+| `e2e/team-stats.spec.ts` | Crear | Smoke test Playwright: Teams abre sin crash con el nuevo código |
+
+---
+
+## Setup: crear rama de feature
+
+Antes de cualquier tarea, crear la rama:
+
+```bash
+git checkout -b feat/team-stats
+```
 
 ---
 
@@ -801,3 +812,96 @@ Resultado esperado: sin errores.
 git add src/components/TeamsWorkspace.tsx
 git commit -m "feat: add Stats tab to TeamsWorkspace for team analytics"
 ```
+
+---
+
+## Task 4: Playwright smoke test
+
+**Files:**
+- Create: `e2e/team-stats.spec.ts`
+
+El test lanza la app con auth bypassed y verifica que TeamsWorkspace abre sin crash con el nuevo código integrado. El test de Stats en sí (con equipo real, token GitHub real) lo hace Gero en Mac/Linux con su cuenta.
+
+**Nota:** Playwright requiere que el app esté buildeada. El workflow de CI ya lo hace antes de correr e2e. Localmente: `npm run build` antes de `npm run test:e2e`.
+
+---
+
+- [ ] **Step 1: Crear `e2e/team-stats.spec.ts`**
+
+```typescript
+import { test } from '@playwright/test'
+import { launchHarness, teardown, expect } from './helpers/harness'
+
+test('TeamsWorkspace opens without crash after Stats tab integration', async () => {
+  const h = await launchHarness({ withRepo: false })
+
+  // Click the Teams button in the sidebar
+  await h.page.locator('.sidebar-item-team').click()
+
+  // TeamsWorkspace mounts — either the empty state (no team) or the full workspace
+  await expect(h.page.locator('.teams-workspace')).toBeVisible({ timeout: 10_000 })
+
+  // No JS error overlay should be visible
+  await expect(h.page.locator('.error-boundary-fallback')).not.toBeVisible()
+
+  await teardown(h)
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add e2e/team-stats.spec.ts
+git commit -m "test: add Playwright smoke test for Stats tab in TeamsWorkspace"
+```
+
+---
+
+## Task 5: Crear el PR
+
+- [ ] **Step 1: Push de la rama**
+
+```bash
+git push origin feat/team-stats
+```
+
+- [ ] **Step 2: Crear el PR**
+
+```bash
+gh pr create \
+  --title "feat: Team Stats tab — activity dashboard for team leaders" \
+  --body "$(cat <<'EOF'
+## Qué hace
+
+Agrega una nueva sección **Stats** al `TeamsWorkspace` que muestra métricas de actividad de la última semana por developer, usando datos que ya fluyen por el app (GitHub Events API + Supabase Presence). Sin migraciones de base de datos.
+
+## Pantallas
+
+- **Overview cards:** devs online ahora, commits totales, PRs mergeados, developer más activo
+- **Tabla de developers:** avatar, estado online/offline, commits, PRs, issues cerrados, última actividad — ordenado por commits desc
+
+## Archivos modificados
+
+- `src/hooks/useTeamStats.ts` — nuevo hook, agrega eventos por `actor.login`
+- `src/components/TeamStats.tsx` — nuevo componente
+- `src/styles/global.css` — clases `.ts-*` al final del archivo
+- `src/components/TeamsWorkspace.tsx` — +1 línea en el tipo, +1 nav item, +1 bloque de render
+- `e2e/team-stats.spec.ts` — smoke test Playwright
+
+## Tests
+
+- 7 unit tests en `useTeamStats.test.ts` (aggregation logic)
+- 5 unit tests en `TeamStats.test.tsx` (component render)
+- 1 Playwright smoke test (Teams abre sin crash)
+
+## Para el reviewer (Gero)
+
+- [ ] Verificar en Mac y Linux que el tab Stats aparece correctamente en Teams
+- [ ] Con GitHub conectado y repos de equipo, confirmar que los datos de la semana cargan
+- [ ] Security: el fetch usa el token OAuth ya existente en el hook `useGitHub`, mismo que usa `ActivityFeed`
+- [ ] El e2e requiere `npm run build` previo (igual que los otros specs)
+EOF
+)"
+```
+
+- [ ] **Step 3: Copiar la URL del PR y compartirla**

--- a/docs/superpowers/plans/2026-07-08-team-analytics.md
+++ b/docs/superpowers/plans/2026-07-08-team-analytics.md
@@ -1,0 +1,803 @@
+# Team Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Agregar una sección "Stats" en `TeamsWorkspace` que muestre actividad de la última semana por developer (commits, PRs, quién está online ahora), usando datos que ya fluyen por el app.
+
+**Architecture:** Un nuevo hook `useTeamStats` fetcha los eventos de GitHub (mismo endpoint que usa `ActivityFeed`) y los agrega por `actor.login`. Un componente `TeamStats` renderiza overview cards + tabla de developers. `TeamsWorkspace` recibe el nuevo tab `'stats'` con mínimos cambios: una línea en el tipo, una entrada en `NAV_ITEMS` y un bloque de render.
+
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react, GitHub REST API (`/repos/:owner/:repo/events`), Supabase Realtime (presence ya existente).
+
+## Global Constraints
+
+- TypeScript estricto — no `any`
+- Tests con Vitest (`import { describe, it, expect, vi } from 'vitest'`)
+- Estilos: inline styles o clases ya existentes en `global.css` para los nuevos elementos simples; agregar clases nuevas al final del archivo para layout
+- No crear archivos CSS separados — todo en `src/styles/global.css`
+- `per_page=100` en el fetch de eventos (el ActivityFeed usa 10; necesitamos más para cubrir la semana)
+- Correr tests con `npm test` (alias de `vitest run`)
+
+---
+
+## Estructura de archivos
+
+| Archivo | Acción | Responsabilidad |
+|---------|--------|-----------------|
+| `src/hooks/useTeamStats.ts` | Crear | Fetch + agregación de eventos GitHub por developer |
+| `src/__tests__/hooks/useTeamStats.test.ts` | Crear | Tests unitarios de la lógica de agregación |
+| `src/components/TeamStats.tsx` | Crear | UI: overview cards + tabla de developers |
+| `src/__tests__/components/TeamStats.test.tsx` | Crear | Tests del componente |
+| `src/styles/global.css` | Modificar | Agregar clases `.ts-*` al final del archivo |
+| `src/components/TeamsWorkspace.tsx` | Modificar | Agregar `'stats'` al tipo, nav item y render |
+
+---
+
+## Task 1: Hook `useTeamStats` — fetch y agregación
+
+**Files:**
+- Create: `src/hooks/useTeamStats.ts`
+- Create: `src/__tests__/hooks/useTeamStats.test.ts`
+
+**Interfaces:**
+- Produce: `aggregateEvents(events: GitHubEvent[]): DeveloperStats[]` (exportada para testear)
+- Produce: `useTeamStats(repos, githubToken): { stats: TeamStatsData; loading: boolean; error: string | null }`
+
+---
+
+- [ ] **Step 1: Escribir el test de agregación**
+
+Crear `src/__tests__/hooks/useTeamStats.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { aggregateEvents } from '../../hooks/useTeamStats'
+
+const NOW = new Date().toISOString()
+const OLD = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString() // 8 días atrás
+
+const makeEvent = (
+  id: string,
+  login: string,
+  type: string,
+  created_at: string,
+  payload: object = {}
+) => ({
+  id,
+  type,
+  actor: { login, avatar_url: `https://avatars.githubusercontent.com/u/1?v=4` },
+  created_at,
+  payload,
+})
+
+describe('aggregateEvents', () => {
+  it('cuenta commits de PushEvent de esta semana', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'fix' }, { sha: 'b', message: 'feat' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].login).toBe('alice')
+    expect(result[0].commits).toBe(2)
+  })
+
+  it('ignora eventos de hace más de 7 días', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', OLD, { commits: [{ sha: 'a', message: 'old' }] }),
+    ]
+    expect(aggregateEvents(events)).toHaveLength(0)
+  })
+
+  it('cuenta PRs abiertos y mergeados por separado', () => {
+    const events = [
+      makeEvent('1', 'bob', 'PullRequestEvent', NOW, { action: 'opened' }),
+      makeEvent('2', 'bob', 'PullRequestEvent', NOW, { action: 'closed', pull_request: { merged: true } }),
+      makeEvent('3', 'bob', 'PullRequestEvent', NOW, { action: 'closed', pull_request: { merged: false } }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].prsOpened).toBe(1)
+    expect(result[0].prsMerged).toBe(1)
+  })
+
+  it('cuenta issues cerrados', () => {
+    const events = [
+      makeEvent('1', 'carol', 'IssuesEvent', NOW, { action: 'closed' }),
+      makeEvent('2', 'carol', 'IssuesEvent', NOW, { action: 'opened' }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].issuesClosed).toBe(1)
+  })
+
+  it('agrupa múltiples eventos del mismo developer', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('2', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'b', message: 'y' }, { sha: 'c', message: 'z' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].commits).toBe(3)
+  })
+
+  it('ordena por commits descendente', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('2', 'bob', 'PushEvent', NOW, { commits: [{ sha: 'b', message: 'y' }, { sha: 'c', message: 'z' }, { sha: 'd', message: 'w' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].login).toBe('bob')
+    expect(result[1].login).toBe('alice')
+  })
+
+  it('deduplica eventos con el mismo id', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].commits).toBe(1)
+  })
+})
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+npm test -- useTeamStats
+```
+
+Resultado esperado: `Error: Failed to resolve import "../../hooks/useTeamStats"`
+
+- [ ] **Step 3: Implementar `useTeamStats.ts`**
+
+Crear `src/hooks/useTeamStats.ts`:
+
+```typescript
+import { useState, useEffect, useMemo } from 'react'
+
+export interface DeveloperStats {
+  login: string
+  avatarUrl: string
+  commits: number
+  prsOpened: number
+  prsMerged: number
+  issuesClosed: number
+  lastEventAt: string | null
+}
+
+export interface TeamStatsData {
+  developers: DeveloperStats[]
+  totalCommits: number
+  totalPrsMerged: number
+  topDeveloper: DeveloperStats | null
+}
+
+interface GitHubEvent {
+  id: string
+  type: string
+  actor: { login: string; avatar_url: string }
+  created_at: string
+  payload: {
+    action?: string
+    commits?: { sha: string; message: string }[]
+    pull_request?: { merged?: boolean }
+  }
+}
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+function isThisWeek(dateStr: string): boolean {
+  return Date.now() - new Date(dateStr).getTime() < ONE_WEEK_MS
+}
+
+export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
+  const map = new Map<string, DeveloperStats>()
+  const seen = new Set<string>()
+
+  for (const event of events) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    if (!isThisWeek(event.created_at)) continue
+
+    const { login, avatar_url } = event.actor
+    if (!map.has(login)) {
+      map.set(login, {
+        login,
+        avatarUrl: avatar_url,
+        commits: 0,
+        prsOpened: 0,
+        prsMerged: 0,
+        issuesClosed: 0,
+        lastEventAt: null,
+      })
+    }
+    const dev = map.get(login)!
+
+    if (!dev.lastEventAt || event.created_at > dev.lastEventAt) {
+      dev.lastEventAt = event.created_at
+    }
+
+    if (event.type === 'PushEvent') {
+      dev.commits += event.payload.commits?.length ?? 0
+    } else if (event.type === 'PullRequestEvent') {
+      if (event.payload.action === 'opened') dev.prsOpened++
+      if (event.payload.action === 'closed' && event.payload.pull_request?.merged) dev.prsMerged++
+    } else if (event.type === 'IssuesEvent' && event.payload.action === 'closed') {
+      dev.issuesClosed++
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.commits - a.commits)
+}
+
+export function useTeamStats(
+  repos: Array<{ repo_full_name: string }>,
+  githubToken: string | null
+): { stats: TeamStatsData; loading: boolean; error: string | null } {
+  const [events, setEvents] = useState<GitHubEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const repoNames = useMemo(
+    () => repos.map(r => r.repo_full_name).join(','),
+    [repos]
+  )
+
+  useEffect(() => {
+    if (!githubToken || !repoNames) return
+    const repoList = repoNames.split(',').filter(Boolean)
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    const load = async () => {
+      try {
+        const results = await Promise.allSettled(
+          repoList.map(name =>
+            fetch(`https://api.github.com/repos/${name}/events?per_page=100`, {
+              headers: {
+                Authorization: `Bearer ${githubToken}`,
+                Accept: 'application/vnd.github.v3+json',
+              },
+            }).then(res => (res.ok ? (res.json() as Promise<GitHubEvent[]>) : ([] as GitHubEvent[])))
+          )
+        )
+        const all: GitHubEvent[] = []
+        for (const r of results) {
+          if (r.status === 'fulfilled') all.push(...r.value)
+        }
+        if (alive) setEvents(all)
+      } catch (e) {
+        if (alive) setError(e instanceof Error ? e.message : 'Failed to load stats')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => { alive = false }
+  }, [repoNames, githubToken])
+
+  const developers = useMemo(() => aggregateEvents(events), [events])
+  const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
+  const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
+  const topDeveloper = developers[0] ?? null
+
+  return {
+    stats: { developers, totalCommits, totalPrsMerged, topDeveloper },
+    loading,
+    error,
+  }
+}
+```
+
+- [ ] **Step 4: Correr los tests y verificar que pasan**
+
+```bash
+npm test -- useTeamStats
+```
+
+Resultado esperado: `7 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useTeamStats.ts src/__tests__/hooks/useTeamStats.test.ts
+git commit -m "feat: add useTeamStats hook with GitHub event aggregation"
+```
+
+---
+
+## Task 2: Componente `TeamStats` — UI
+
+**Files:**
+- Create: `src/components/TeamStats.tsx`
+- Create: `src/__tests__/components/TeamStats.test.tsx`
+- Modify: `src/styles/global.css` — agregar clases `.ts-*` al final
+
+**Interfaces:**
+- Consume: `useTeamStats(repos, githubToken)` → `{ stats: TeamStatsData, loading, error }`
+- Consume: `presence: Record<string, PresenceState>` (de `useTeamPresence`)
+- Props:
+  ```typescript
+  interface TeamStatsProps {
+    repos: Array<{ repo_full_name: string }>
+    githubToken: string | null
+    presence: Record<string, PresenceState>
+  }
+  ```
+
+---
+
+- [ ] **Step 1: Escribir el test del componente**
+
+Crear `src/__tests__/components/TeamStats.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import TeamStats from '../../components/TeamStats'
+
+vi.mock('../../hooks/useTeamStats', () => ({
+  useTeamStats: () => ({
+    stats: {
+      developers: [
+        {
+          login: 'alice',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+          commits: 12,
+          prsOpened: 2,
+          prsMerged: 1,
+          issuesClosed: 3,
+          lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+        {
+          login: 'bob',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
+          commits: 4,
+          prsOpened: 0,
+          prsMerged: 0,
+          issuesClosed: 0,
+          lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+        },
+      ],
+      totalCommits: 16,
+      totalPrsMerged: 1,
+      topDeveloper: {
+        login: 'alice',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        commits: 12,
+        prsOpened: 2,
+        prsMerged: 1,
+        issuesClosed: 3,
+        lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    },
+    loading: false,
+    error: null,
+  }),
+}))
+
+const presence = {
+  'user-alice': { userId: 'user-alice', displayName: 'alice@co.com', repo: 'org/repo', branch: 'main', lastSeen: new Date().toISOString() },
+}
+
+const defaultProps = {
+  repos: [{ repo_full_name: 'org/repo' }],
+  githubToken: 'token',
+  presence,
+}
+
+describe('TeamStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('muestra el conteo de commits totales en las cards de overview', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('16')).toBeTruthy()
+  })
+
+  it('muestra el developer más activo', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('alice')).toBeTruthy()
+  })
+
+  it('muestra el conteo de developers online desde presence', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('1')).toBeTruthy()
+  })
+
+  it('muestra la tabla con ambos developers', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('alice')).toBeTruthy()
+    expect(screen.getByText('bob')).toBeTruthy()
+  })
+
+  it('muestra mensaje de conectar GitHub cuando no hay token', () => {
+    render(<TeamStats {...defaultProps} githubToken={null} />)
+    expect(screen.getByText(/connect your github/i)).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+npm test -- "TeamStats.test"
+```
+
+Resultado esperado: `Error: Failed to resolve import "../../components/TeamStats"`
+
+- [ ] **Step 3: Agregar clases CSS al final de `src/styles/global.css`**
+
+Agregar al final del archivo:
+
+```css
+/* ── Team Stats ──────────────────────────────────────────── */
+.ts-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 14px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.ts-overview-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.ts-card {
+  background: #ffffff08;
+  border: 1px solid #ffffff12;
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ts-card-label {
+  font-size: 10px;
+  color: #ffffff55;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ts-card-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: #fff;
+  line-height: 1;
+}
+
+.ts-card-sub {
+  font-size: 11px;
+  color: #ffffff66;
+}
+
+.ts-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #ffffff55;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+
+.ts-table-wrap {
+  overflow-x: auto;
+}
+
+.ts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.ts-table th {
+  text-align: left;
+  font-size: 10px;
+  font-weight: 500;
+  color: #ffffff44;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 8px 8px;
+  white-space: nowrap;
+}
+
+.ts-table th:first-child { padding-left: 0; }
+
+.ts-table td {
+  padding: 6px 8px;
+  color: #ffffffcc;
+  border-top: 1px solid #ffffff08;
+  vertical-align: middle;
+}
+
+.ts-table td:first-child { padding-left: 0; }
+
+.ts-table tr:hover td { background: #ffffff05; }
+
+.ts-dev-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ts-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ts-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ts-status-dot.online  { background: #22c55e; }
+.ts-status-dot.offline { background: #ffffff22; }
+
+.ts-num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.ts-muted { color: #ffffff44; }
+
+.ts-empty {
+  padding: 40px 0;
+  text-align: center;
+  color: #ffffff44;
+  font-size: 12px;
+}
+```
+
+- [ ] **Step 4: Implementar `TeamStats.tsx`**
+
+Crear `src/components/TeamStats.tsx`:
+
+```typescript
+import { useTeamStats } from '../hooks/useTeamStats'
+import type { PresenceState } from '../hooks/useTeamPresence'
+
+interface TeamStatsProps {
+  repos: Array<{ repo_full_name: string }>
+  githubToken: string | null
+  presence: Record<string, PresenceState>
+}
+
+function timeAgo(dateStr: string | null): string {
+  if (!dateStr) return '—'
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h`
+  return `${Math.floor(hrs / 24)}d`
+}
+
+export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
+  const { stats, loading, error } = useTeamStats(repos, githubToken)
+  const onlineCount = Object.keys(presence).length
+  const onlineLogins = new Set(
+    Object.values(presence).map(p => p.displayName.split('@')[0].toLowerCase())
+  )
+
+  if (!githubToken) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">Connect your GitHub account to see team stats</div>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">Loading stats…</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">{error}</div>
+      </div>
+    )
+  }
+
+  const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
+
+  return (
+    <div className="ts-container">
+      {/* Overview cards */}
+      <div>
+        <div className="ts-section-title">This week</div>
+        <div className="ts-overview-row">
+          <div className="ts-card">
+            <span className="ts-card-label">Online now</span>
+            <span className="ts-card-value">{onlineCount}</span>
+            <span className="ts-card-sub">developers active</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">Commits</span>
+            <span className="ts-card-value">{totalCommits}</span>
+            <span className="ts-card-sub">across all repos</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">PRs merged</span>
+            <span className="ts-card-value">{totalPrsMerged}</span>
+            <span className="ts-card-sub">this week</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">Top dev</span>
+            <span className="ts-card-value" style={{ fontSize: 14, paddingTop: 4 }}>
+              {topDeveloper ? `@${topDeveloper.login}` : '—'}
+            </span>
+            <span className="ts-card-sub">
+              {topDeveloper ? `${topDeveloper.commits} commits` : 'no activity'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Developer table */}
+      <div>
+        <div className="ts-section-title">Developers</div>
+        {developers.length === 0 ? (
+          <div className="ts-empty">No activity in the last 7 days</div>
+        ) : (
+          <div className="ts-table-wrap">
+            <table className="ts-table">
+              <thead>
+                <tr>
+                  <th>Developer</th>
+                  <th style={{ textAlign: 'right' }}>Commits</th>
+                  <th style={{ textAlign: 'right' }}>PRs</th>
+                  <th style={{ textAlign: 'right' }}>Issues</th>
+                  <th style={{ textAlign: 'right' }}>Last activity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {developers.map(dev => {
+                  const isOnline = onlineLogins.has(dev.login.toLowerCase())
+                  return (
+                    <tr key={dev.login}>
+                      <td>
+                        <div className="ts-dev-cell">
+                          <span className={`ts-status-dot ${isOnline ? 'online' : 'offline'}`} />
+                          <img
+                            className="ts-avatar"
+                            src={dev.avatarUrl}
+                            alt={dev.login}
+                          />
+                          <span>{dev.login}</span>
+                        </div>
+                      </td>
+                      <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num ts-muted">{timeAgo(dev.lastEventAt)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Correr los tests y verificar que pasan**
+
+```bash
+npm test -- "TeamStats.test"
+```
+
+Resultado esperado: `5 passed`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/TeamStats.tsx src/__tests__/components/TeamStats.test.tsx src/styles/global.css
+git commit -m "feat: add TeamStats component with overview cards and developer table"
+```
+
+---
+
+## Task 3: Integrar en `TeamsWorkspace`
+
+**Files:**
+- Modify: `src/components/TeamsWorkspace.tsx`
+
+**Interfaces:**
+- Consume: `TeamStats` (default export de `src/components/TeamStats.tsx`)
+- Consume: Props ya disponibles en `TeamsWorkspace`: `repos`, `githubToken`, `presence`
+
+---
+
+- [ ] **Step 1: Agregar `'stats'` al tipo `WorkspaceSection`**
+
+En `src/components/TeamsWorkspace.tsx`, línea 44, cambiar:
+
+```typescript
+// Antes:
+type WorkspaceSection = 'activity' | 'chat' | 'repos' | 'issues' | 'members' | 'snippets' | 'workspaces' | 'mcp' | 'pendings'
+
+// Después:
+type WorkspaceSection = 'activity' | 'chat' | 'repos' | 'issues' | 'members' | 'snippets' | 'workspaces' | 'mcp' | 'pendings' | 'stats'
+```
+
+- [ ] **Step 2: Agregar el import de `TeamStats`**
+
+Después de la línea que importa `TeamJoinCodePanel` (aprox. línea 32), agregar:
+
+```typescript
+import TeamStats from './TeamStats'
+```
+
+- [ ] **Step 3: Agregar el nav item de Stats en `NAV_ITEMS`**
+
+Agregar después del item `'members'` (después de la línea 364 aprox), antes del item `'snippets'`:
+
+```typescript
+{
+  id: 'stats',
+  label: 'Stats',
+  icon: (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+      <rect x="1" y="9" width="3" height="5" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+      <rect x="6" y="5" width="3" height="9" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+      <rect x="11" y="2" width="3" height="12" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+    </svg>
+  ),
+},
+```
+
+- [ ] **Step 4: Agregar el bloque de render para la sección `'stats'`**
+
+Buscar el último bloque de sección antes del cierre `</ErrorBoundary>` (aprox. línea 1255, sección `'mcp'`). Después de ese bloque, agregar:
+
+```typescript
+{!creatingTeam && section === 'stats' && (
+  <TeamStats
+    repos={repos.map(r => ({ repo_full_name: r.repo_full_name }))}
+    githubToken={githubToken}
+    presence={presence}
+  />
+)}
+```
+
+- [ ] **Step 5: Correr todos los tests**
+
+```bash
+npm test
+```
+
+Resultado esperado: todos los tests previos siguen pasando + los nuevos.
+
+- [ ] **Step 6: Verificar TypeScript**
+
+```bash
+npm run typecheck 2>/dev/null || npx tsc --noEmit
+```
+
+Resultado esperado: sin errores.
+
+- [ ] **Step 7: Commit final**
+
+```bash
+git add src/components/TeamsWorkspace.tsx
+git commit -m "feat: add Stats tab to TeamsWorkspace for team analytics"
+```

--- a/docs/superpowers/specs/2026-07-08-team-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-08-team-analytics-design.md
@@ -1,0 +1,102 @@
+# Team Analytics — Design Spec
+**Fecha:** 2026-07-08  
+**Contexto:** Reunión con aceleradora que quiere usar Nest para 45 developers. Pidieron visibilidad de actividad por developer (quién hace más, qué hace, cuánto).
+
+---
+
+## Objetivo
+
+Agregar una sección "Stats" dentro del `TeamsWorkspace` existente que muestre métricas de actividad por developer, usando datos que ya fluyen por el app (GitHub events + Supabase Presence). Sin migraciones nuevas de base de datos.
+
+---
+
+## Lo que se construye
+
+### 1. Hook `useTeamStats.ts`
+
+Agrega los eventos de GitHub (ya disponibles vía GitHub API) por developer y los combina con presence data.
+
+**Input:**
+- `events: GitHubEvent[]` — los mismos que ya usa `ActivityFeed`
+- `presence: Record<string, PresenceState>` — del hook `useTeamPresence` ya existente
+- `teamMembers: Array<{ email: string; user_id: string | null }>` — ya disponible en TeamsWorkspace
+
+**Output por developer:**
+```ts
+interface DeveloperStats {
+  login: string           // GitHub username
+  avatarUrl: string
+  isOnline: boolean       // de presence
+  currentRepo: string | null   // de presence
+  currentBranch: string | null // de presence
+  lastSeen: string        // de presence
+  commits: number         // PushEvents esta semana
+  prsOpened: number       // PullRequestEvent opened
+  prsMerged: number       // PullRequestEvent merged
+  issuesClosed: number    // IssuesEvent closed
+  lastEventAt: string     // último evento GitHub
+}
+```
+
+**Lógica de matching:** los eventos GitHub incluyen `actor.login` y `actor.avatar_url`. Se agrupa por `actor.login` directamente — no se intenta hacer match con emails de teamMembers (que son Supabase IDs, no GitHub logins). El presence online/offline se muestra como un panel separado por displayName. En Fase 2, cuando se guarde el GitHub login en el perfil de Supabase, se puede hacer el merge completo.
+
+### 2. Componente `TeamStats.tsx`
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────┐
+│  OVERVIEW                                            │
+│  [🟢 12 activos ahora] [📦 47 commits] [⬡ 8 PRs]  │
+│  [🏆 top: @maticodes]                               │
+├─────────────────────────────────────────────────────┤
+│  DEVELOPERS                                          │
+│  Avatar  Nombre    Estado  Repo/Branch  C   PR  Last │
+│  ●       @alice    🟢      main-api/feat 12   3   2m │
+│  ●       @bob      ⚫      —            4    1   3h  │
+│  ...                                                 │
+└─────────────────────────────────────────────────────┘
+```
+
+- Ordenado por commits (descendente) por defecto
+- Columnas: Avatar, login, estado online, repo+branch actual, commits semana, PRs, última actividad
+- Estado 🟢 si está en presence actualmente, ⚫ si no
+- Muestra "N/A" si el developer no tiene GitHub conectado
+
+### 3. Integración en `TeamsWorkspace.tsx`
+
+- Agregar `'stats'` al tipo `WorkspaceSection`
+- Agregar botón "Stats" en la barra de navegación de secciones (junto a activity, chat, repos, etc.)
+- Pasar `events` (del fetch de ActivityFeed) y `presence` al nuevo componente
+
+---
+
+## Lo que NO se construye en esta iteración
+
+- Sesiones de IA por developer (requiere instrumentar PTY por usuario + tabla nueva)
+- Tiempo en terminal (requiere persistent session tracking)
+- Historial más allá de la semana (requiere DB nueva)
+- Notificaciones de inactividad
+- Exportar datos a CSV
+
+Estas capacidades van en una Fase 2 post-reunión si el deal se cierra.
+
+---
+
+## Archivos a crear/modificar
+
+| Archivo | Acción |
+|---------|--------|
+| `src/hooks/useTeamStats.ts` | Crear |
+| `src/components/TeamStats.tsx` | Crear |
+| `src/components/TeamsWorkspace.tsx` | Modificar — agregar sección 'stats' + nav tab |
+
+---
+
+## Criterio de éxito para la demo
+
+En la reunión se puede mostrar en vivo:
+1. La tabla de developers con quién está online ahora
+2. Commits y PRs de la semana por developer
+3. Ordenar por actividad y ver quién es el más productivo
+
+Con 45 developers reales del cliente, el impacto visual es inmediato.

--- a/e2e/team-stats.spec.ts
+++ b/e2e/team-stats.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '@playwright/test'
+import { launchHarness, teardown, expect } from './helpers/harness'
+
+test('TeamsWorkspace opens without crash after Stats tab integration', async () => {
+  const h = await launchHarness({ withRepo: false })
+
+  // Click the Teams button in the sidebar
+  await h.page.locator('.sidebar-item-team').click()
+
+  // TeamsWorkspace mounts — either the empty state (no team) or the full workspace
+  await expect(h.page.locator('.teams-workspace')).toBeVisible({ timeout: 10_000 })
+
+  // No JS error overlay should be visible
+  await expect(h.page.locator('.error-boundary-fallback')).not.toBeVisible()
+
+  await teardown(h)
+})

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -97,12 +97,6 @@ describe('TeamStats', () => {
     expect(screen.getByText(/connect your github/i)).toBeTruthy()
   })
 
-  it('muestra el feed de PRs mergeados', () => {
-    render(<TeamStats {...defaultProps} />)
-    expect(screen.getByText('feat: add team stats dashboard')).toBeTruthy()
-    expect(screen.getByText('merged')).toBeTruthy()
-  })
-
   it('renderiza la sparkline (7 barras por developer)', () => {
     render(<TeamStats {...defaultProps} />)
     const sparkBars = document.querySelectorAll('.ts-spark-bar')

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -38,12 +38,14 @@ const LOADED: { stats: TeamStatsData; loading: boolean; error: string | null } =
         mergedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       },
     ],
+    prevCommits: 10,
+    prevPrsMerged: 2,
   },
   loading: false,
   error: null,
 }
 const EMPTY: { stats: TeamStatsData; loading: boolean; error: string | null } = {
-  stats: { developers: [], totalCommits: 0, totalPrsMerged: 0, topDeveloper: null, recentPrs: [] },
+  stats: { developers: [], totalCommits: 0, totalPrsMerged: 0, topDeveloper: null, recentPrs: [], prevCommits: 0, prevPrsMerged: 0 },
   loading: false,
   error: null,
 }
@@ -71,7 +73,7 @@ describe('TeamStats', () => {
     // Si el useMemo está después de un early return, este rerender tira
     // "Rendered more hooks than during the previous render".
     expect(() => rerender(<TeamStats {...defaultProps} />)).not.toThrow()
-    expect(screen.getByText('alice')).toBeTruthy()
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0)
   })
 
   it('muestra el conteo de commits totales en las cards de overview', () => {
@@ -81,7 +83,7 @@ describe('TeamStats', () => {
 
   it('muestra el developer más activo', () => {
     render(<TeamStats {...defaultProps} />)
-    expect(screen.getByText('alice')).toBeTruthy()
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0)
   })
 
   it('muestra el conteo de developers online desde presence', () => {
@@ -91,9 +93,10 @@ describe('TeamStats', () => {
   })
 
   it('muestra la tabla con ambos developers', () => {
-    render(<TeamStats {...defaultProps} />)
-    expect(screen.getByText('alice')).toBeTruthy()
-    expect(screen.getByText('bob')).toBeTruthy()
+    const { container } = render(<TeamStats {...defaultProps} />)
+    const table = container.querySelector('.ts-table') as HTMLElement
+    expect(within(table).getByText('alice')).toBeTruthy()
+    expect(within(table).getByText('bob')).toBeTruthy()
   })
 
   it('muestra mensaje de conectar GitHub cuando no hay token', () => {

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../hooks/useTeamStats', () => ({
           prsMerged: 1,
           issuesClosed: 3,
           lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+          dailyCommits: [0, 2, 4, 1, 3, 2, 0],
         },
         {
           login: 'bob',
@@ -23,6 +24,7 @@ vi.mock('../../hooks/useTeamStats', () => ({
           prsMerged: 0,
           issuesClosed: 0,
           lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+          dailyCommits: [0, 0, 1, 0, 2, 1, 0],
         },
       ],
       totalCommits: 16,
@@ -35,7 +37,18 @@ vi.mock('../../hooks/useTeamStats', () => ({
         prsMerged: 1,
         issuesClosed: 3,
         lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        dailyCommits: [0, 2, 4, 1, 3, 2, 0],
       },
+      recentPrs: [
+        {
+          id: 'evt-1',
+          login: 'alice',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+          title: 'feat: add team stats dashboard',
+          repo: 'org/repo',
+          mergedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        },
+      ],
     },
     loading: false,
     error: null,
@@ -82,5 +95,18 @@ describe('TeamStats', () => {
   it('muestra mensaje de conectar GitHub cuando no hay token', () => {
     render(<TeamStats {...defaultProps} githubToken={null} />)
     expect(screen.getByText(/connect your github/i)).toBeTruthy()
+  })
+
+  it('muestra el feed de PRs mergeados', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('feat: add team stats dashboard')).toBeTruthy()
+    expect(screen.getByText('merged')).toBeTruthy()
+  })
+
+  it('renderiza la sparkline (7 barras por developer)', () => {
+    render(<TeamStats {...defaultProps} />)
+    const sparkBars = document.querySelectorAll('.ts-spark-bar')
+    // 2 developers × 7 bars each = 14
+    expect(sparkBars.length).toBe(14)
   })
 })

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -97,10 +97,10 @@ describe('TeamStats', () => {
     expect(screen.getByText(/connect your github/i)).toBeTruthy()
   })
 
-  it('renderiza la sparkline (7 barras por developer)', () => {
+  it('renderiza una sparkline SVG por developer', () => {
     render(<TeamStats {...defaultProps} />)
-    const sparkBars = document.querySelectorAll('.ts-spark-bar')
-    // 2 developers × 7 bars each = 14
-    expect(sparkBars.length).toBe(14)
+    const sparks = document.querySelectorAll('.ts-spark')
+    // 1 SVG sparkline per developer
+    expect(sparks.length).toBe(2)
   })
 })

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import TeamStats, { onlineGithubLogins } from '../../components/TeamStats'
 import type { TeamStatsData } from '../../hooks/useTeamStats'
 
@@ -106,6 +106,32 @@ describe('TeamStats', () => {
     const sparks = document.querySelectorAll('.ts-spark')
     // 1 SVG sparkline per developer
     expect(sparks.length).toBe(2)
+  })
+
+  it('muestra el skeleton mientras carga', () => {
+    mockUseTeamStats.mockReturnValue({ ...EMPTY, loading: true })
+    const { container } = render(<TeamStats {...defaultProps} />)
+    expect(container.querySelector('[aria-busy="true"]')).toBeTruthy()
+    expect(container.querySelectorAll('.ts-skeleton').length).toBeGreaterThan(0)
+  })
+
+  it('muestra el mensaje de error', () => {
+    mockUseTeamStats.mockReturnValue({ ...EMPTY, error: 'API rate limit exceeded' })
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('API rate limit exceeded')).toBeTruthy()
+  })
+
+  it('reordena por PRs al clickear el header', () => {
+    const { getByRole } = render(<TeamStats {...defaultProps} />)
+    // Orden inicial: por commits desc → alice (12) antes que bob (4)
+    let names = Array.from(document.querySelectorAll('.ts-dev-name')).map(n => n.textContent)
+    expect(names).toEqual(['alice', 'bob'])
+    // Click en "PRs": alice tiene 3 (2+1), bob 0. 1er click = desc, 2do = asc → invierte.
+    const prsHeader = getByRole('button', { name: /PRs/i })
+    fireEvent.click(prsHeader)  // desc por prs
+    fireEvent.click(prsHeader)  // asc por prs
+    names = Array.from(document.querySelectorAll('.ts-dev-name')).map(n => n.textContent)
+    expect(names).toEqual(['bob', 'alice'])
   })
 })
 

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -1,62 +1,55 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import TeamStats from '../../components/TeamStats'
+import type { TeamStatsData } from '../../hooks/useTeamStats'
 
+const mockUseTeamStats = vi.fn()
 vi.mock('../../hooks/useTeamStats', () => ({
-  useTeamStats: () => ({
-    stats: {
-      developers: [
-        {
-          login: 'alice',
-          avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
-          commits: 12,
-          prsOpened: 2,
-          prsMerged: 1,
-          issuesClosed: 3,
-          lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-          dailyCommits: [0, 2, 4, 1, 3, 2, 0],
-        },
-        {
-          login: 'bob',
-          avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
-          commits: 4,
-          prsOpened: 0,
-          prsMerged: 0,
-          issuesClosed: 0,
-          lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
-          dailyCommits: [0, 0, 1, 0, 2, 1, 0],
-        },
-      ],
-      totalCommits: 16,
-      totalPrsMerged: 1,
-      topDeveloper: {
-        login: 'alice',
-        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
-        commits: 12,
-        prsOpened: 2,
-        prsMerged: 1,
-        issuesClosed: 3,
-        lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-        dailyCommits: [0, 2, 4, 1, 3, 2, 0],
-      },
-      recentPrs: [
-        {
-          id: 'evt-1',
-          login: 'alice',
-          avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
-          title: 'feat: add team stats dashboard',
-          repo: 'org/repo',
-          mergedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-        },
-      ],
-    },
-    loading: false,
-    error: null,
-  }),
+  useTeamStats: (...args: unknown[]) => mockUseTeamStats(...args),
 }))
 
+const DEV_ALICE = {
+  login: 'alice',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+  commits: 12, prsOpened: 2, prsMerged: 1, issuesClosed: 3,
+  lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  dailyCommits: [0, 2, 4, 1, 3, 2, 0],
+}
+const DEV_BOB = {
+  login: 'bob',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
+  commits: 4, prsOpened: 0, prsMerged: 0, issuesClosed: 0,
+  lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  dailyCommits: [0, 0, 1, 0, 2, 1, 0],
+}
+const LOADED: { stats: TeamStatsData; loading: boolean; error: string | null } = {
+  stats: {
+    developers: [DEV_ALICE, DEV_BOB],
+    totalCommits: 16,
+    totalPrsMerged: 1,
+    topDeveloper: DEV_ALICE,
+    recentPrs: [
+      {
+        id: 'evt-1',
+        login: 'alice',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        title: 'feat: add team stats dashboard',
+        repo: 'org/repo',
+        mergedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      },
+    ],
+  },
+  loading: false,
+  error: null,
+}
+const EMPTY: { stats: TeamStatsData; loading: boolean; error: string | null } = {
+  stats: { developers: [], totalCommits: 0, totalPrsMerged: 0, topDeveloper: null, recentPrs: [] },
+  loading: false,
+  error: null,
+}
+
 const presence = {
-  'user-alice': { userId: 'user-alice', displayName: 'alice@co.com', repo: 'org/repo', branch: 'main', lastSeen: new Date().toISOString() },
+  'user-alice': { userId: 'user-alice', displayName: 'alice@co.com', githubLogin: 'alice', repo: 'org/repo', branch: 'main', lastSeen: new Date().toISOString() },
 }
 
 const defaultProps = {
@@ -68,6 +61,17 @@ const defaultProps = {
 describe('TeamStats', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseTeamStats.mockReturnValue(LOADED)
+  })
+
+  it('no crashea al pasar de loading a cargado (orden de hooks)', () => {
+    mockUseTeamStats.mockReturnValue({ ...EMPTY, loading: true })
+    const { rerender } = render(<TeamStats {...defaultProps} />)
+    mockUseTeamStats.mockReturnValue(LOADED)
+    // Si el useMemo está después de un early return, este rerender tira
+    // "Rendered more hooks than during the previous render".
+    expect(() => rerender(<TeamStats {...defaultProps} />)).not.toThrow()
+    expect(screen.getByText('alice')).toBeTruthy()
   })
 
   it('muestra el conteo de commits totales en las cards de overview', () => {

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import TeamStats from '../../components/TeamStats'
+
+vi.mock('../../hooks/useTeamStats', () => ({
+  useTeamStats: () => ({
+    stats: {
+      developers: [
+        {
+          login: 'alice',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+          commits: 12,
+          prsOpened: 2,
+          prsMerged: 1,
+          issuesClosed: 3,
+          lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+        {
+          login: 'bob',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
+          commits: 4,
+          prsOpened: 0,
+          prsMerged: 0,
+          issuesClosed: 0,
+          lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+        },
+      ],
+      totalCommits: 16,
+      totalPrsMerged: 1,
+      topDeveloper: {
+        login: 'alice',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        commits: 12,
+        prsOpened: 2,
+        prsMerged: 1,
+        issuesClosed: 3,
+        lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    },
+    loading: false,
+    error: null,
+  }),
+}))
+
+const presence = {
+  'user-alice': { userId: 'user-alice', displayName: 'alice@co.com', repo: 'org/repo', branch: 'main', lastSeen: new Date().toISOString() },
+}
+
+const defaultProps = {
+  repos: [{ repo_full_name: 'org/repo' }],
+  githubToken: 'token',
+  presence,
+}
+
+describe('TeamStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('muestra el conteo de commits totales en las cards de overview', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('16')).toBeTruthy()
+  })
+
+  it('muestra el developer más activo', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('alice')).toBeTruthy()
+  })
+
+  it('muestra el conteo de developers online desde presence', () => {
+    render(<TeamStats {...defaultProps} />)
+    const ones = screen.getAllByText('1')
+    expect(ones.length).toBeGreaterThan(0)
+  })
+
+  it('muestra la tabla con ambos developers', () => {
+    render(<TeamStats {...defaultProps} />)
+    expect(screen.getByText('alice')).toBeTruthy()
+    expect(screen.getByText('bob')).toBeTruthy()
+  })
+
+  it('muestra mensaje de conectar GitHub cuando no hay token', () => {
+    render(<TeamStats {...defaultProps} githubToken={null} />)
+    expect(screen.getByText(/connect your github/i)).toBeTruthy()
+  })
+})

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -11,14 +11,14 @@ vi.mock('../../hooks/useTeamStats', () => ({
 const DEV_ALICE = {
   login: 'alice',
   avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
-  commits: 12, prsOpened: 2, prsMerged: 1, issuesClosed: 3,
+  commits: 12, prsOpened: 2, prsMerged: 1, reviews: 4, issuesClosed: 3,
   lastEventAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
   dailyCommits: [0, 2, 4, 1, 3, 2, 0],
 }
 const DEV_BOB = {
   login: 'bob',
   avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
-  commits: 4, prsOpened: 0, prsMerged: 0, issuesClosed: 0,
+  commits: 4, prsOpened: 0, prsMerged: 0, reviews: 0, issuesClosed: 0,
   lastEventAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
   dailyCommits: [0, 0, 1, 0, 2, 1, 0],
 }
@@ -27,6 +27,8 @@ const LOADED: { stats: TeamStatsData; loading: boolean; error: string | null } =
     developers: [DEV_ALICE, DEV_BOB],
     totalCommits: 16,
     totalPrsMerged: 1,
+    totalReviews: 4,
+    mergeTimeHours: 6,
     topDeveloper: DEV_ALICE,
     recentPrs: [
       {
@@ -45,7 +47,7 @@ const LOADED: { stats: TeamStatsData; loading: boolean; error: string | null } =
   error: null,
 }
 const EMPTY: { stats: TeamStatsData; loading: boolean; error: string | null } = {
-  stats: { developers: [], totalCommits: 0, totalPrsMerged: 0, topDeveloper: null, recentPrs: [], prevCommits: 0, prevPrsMerged: 0 },
+  stats: { developers: [], totalCommits: 0, totalPrsMerged: 0, totalReviews: 0, mergeTimeHours: null, topDeveloper: null, recentPrs: [], prevCommits: 0, prevPrsMerged: 0 },
   loading: false,
   error: null,
 }

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import TeamStats from '../../components/TeamStats'
 
 vi.mock('../../hooks/useTeamStats', () => ({
@@ -69,8 +69,8 @@ describe('TeamStats', () => {
 
   it('muestra el conteo de developers online desde presence', () => {
     render(<TeamStats {...defaultProps} />)
-    const ones = screen.getAllByText('1')
-    expect(ones.length).toBeGreaterThan(0)
+    const onlineCard = screen.getByText('Online now').closest('.ts-card')!
+    expect(within(onlineCard).getByText('1')).toBeTruthy()
   })
 
   it('muestra la tabla con ambos developers', () => {

--- a/src/__tests__/components/TeamStats.test.tsx
+++ b/src/__tests__/components/TeamStats.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
-import TeamStats from '../../components/TeamStats'
+import TeamStats, { onlineGithubLogins } from '../../components/TeamStats'
 import type { TeamStatsData } from '../../hooks/useTeamStats'
 
 const mockUseTeamStats = vi.fn()
@@ -106,5 +106,17 @@ describe('TeamStats', () => {
     const sparks = document.querySelectorAll('.ts-spark')
     // 1 SVG sparkline per developer
     expect(sparks.length).toBe(2)
+  })
+})
+
+describe('onlineGithubLogins', () => {
+  it('devuelve los github logins en minúscula, ignorando nulls', () => {
+    const p = {
+      a: { userId: 'a', displayName: 'x@co.com', githubLogin: 'Alice', repo: null, branch: null, lastSeen: '' },
+      b: { userId: 'b', displayName: 'y@co.com', githubLogin: null, repo: null, branch: null, lastSeen: '' },
+    }
+    const set = onlineGithubLogins(p)
+    expect(set.has('alice')).toBe(true)
+    expect(set.size).toBe(1)
   })
 })

--- a/src/__tests__/hooks/useTeamStats.test.ts
+++ b/src/__tests__/hooks/useTeamStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { aggregateEvents } from '../../hooks/useTeamStats'
+import { aggregateEvents, extractRecentPrs } from '../../hooks/useTeamStats'
 
 const NOW = new Date().toISOString()
 const OLD = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString() // 8 días atrás
@@ -9,11 +9,13 @@ const makeEvent = (
   login: string,
   type: string,
   created_at: string,
-  payload: object = {}
+  payload: object = {},
+  repo = 'owner/repo'
 ) => ({
   id,
   type,
   actor: { login, avatar_url: `https://avatars.githubusercontent.com/u/1?v=4` },
+  repo: { name: repo },
   created_at,
   payload,
 })
@@ -83,5 +85,61 @@ describe('aggregateEvents', () => {
     ]
     const result = aggregateEvents(events)
     expect(result[0].commits).toBe(1)
+  })
+})
+
+describe('extractRecentPrs', () => {
+  it('returns merged PRs with title and repo', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PullRequestEvent', NOW,
+        { action: 'closed', pull_request: { merged: true, title: 'feat: add login' } },
+        'acme/api'),
+    ]
+    const result = extractRecentPrs(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].title).toBe('feat: add login')
+    expect(result[0].repo).toBe('acme/api')
+    expect(result[0].login).toBe('alice')
+  })
+
+  it('ignores unmerged closed PRs', () => {
+    const events = [
+      makeEvent('1', 'bob', 'PullRequestEvent', NOW,
+        { action: 'closed', pull_request: { merged: false, title: 'wip' } }),
+    ]
+    expect(extractRecentPrs(events)).toHaveLength(0)
+  })
+
+  it('ignores events older than 7 days', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PullRequestEvent', OLD,
+        { action: 'closed', pull_request: { merged: true, title: 'old PR' } }),
+    ]
+    expect(extractRecentPrs(events)).toHaveLength(0)
+  })
+
+  it('sorts by mergedAt descending', () => {
+    const earlier = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+    const later   = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()
+    const events = [
+      makeEvent('1', 'alice', 'PullRequestEvent', earlier,
+        { action: 'closed', pull_request: { merged: true, title: 'first' } }),
+      makeEvent('2', 'bob', 'PullRequestEvent', later,
+        { action: 'closed', pull_request: { merged: true, title: 'second' } }),
+    ]
+    const result = extractRecentPrs(events)
+    expect(result[0].title).toBe('second')
+    expect(result[1].title).toBe('first')
+  })
+
+  it('also check dailyCommits populated — today slot incremented', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }, { sha: 'b', message: 'y' }] }),
+    ]
+    const result = aggregateEvents(events)
+    // index 6 = today
+    expect(result[0].dailyCommits[6]).toBe(2)
+    // other slots should be 0
+    expect(result[0].dailyCommits.slice(0, 6).every((v: number) => v === 0)).toBe(true)
   })
 })

--- a/src/__tests__/hooks/useTeamStats.test.ts
+++ b/src/__tests__/hooks/useTeamStats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { aggregateEvents, extractRecentPrs } from '../../hooks/useTeamStats'
+import { aggregateEvents, extractRecentPrs, medianMergeHours } from '../../hooks/useTeamStats'
 
 const NOW = new Date().toISOString()
 const OLD = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString() // 8 días atrás
@@ -88,6 +88,17 @@ describe('aggregateEvents', () => {
     expect(result[0].prsMerged).toBe(1)
   })
 
+  it('cuenta reviews de PullRequestReviewEvent (action created)', () => {
+    const events = [
+      makeEvent('1', 'dana', 'PullRequestReviewEvent', NOW, { action: 'created' }),
+      makeEvent('2', 'dana', 'PullRequestReviewEvent', NOW, { action: 'created' }),
+      makeEvent('3', 'dana', 'PullRequestReviewEvent', NOW, { action: 'dismissed' }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].reviews).toBe(2)
+  })
+
   it('cuenta issues cerrados', () => {
     const events = [
       makeEvent('1', 'carol', 'IssuesEvent', NOW, { action: 'closed' }),
@@ -124,6 +135,35 @@ describe('aggregateEvents', () => {
     ]
     const result = aggregateEvents(events)
     expect(result[0].commits).toBe(1)
+  })
+})
+
+describe('medianMergeHours', () => {
+  const merged = (id: string, createdHoursAgo: number, mergedHoursAgo: number) =>
+    makeEvent(id, 'x', 'PullRequestEvent', new Date(Date.now() - mergedHoursAgo * 3_600_000).toISOString(), {
+      action: 'closed',
+      pull_request: {
+        merged: true,
+        created_at: new Date(Date.now() - createdHoursAgo * 3_600_000).toISOString(),
+        merged_at: new Date(Date.now() - mergedHoursAgo * 3_600_000).toISOString(),
+      },
+    })
+
+  it('devuelve null si no hay PRs mergeados con fechas', () => {
+    expect(medianMergeHours([])).toBeNull()
+    expect(medianMergeHours([makeEvent('1', 'a', 'PushEvent', NOW, {})])).toBeNull()
+  })
+
+  it('calcula la mediana de horas abierto→merge', () => {
+    // duraciones: 2h, 4h, 12h → mediana 4h
+    const events = [merged('1', 3, 1), merged('2', 6, 2), merged('3', 24, 12)]
+    expect(medianMergeHours(events)).toBe(4)
+  })
+
+  it('promedia los dos centrales con cantidad par', () => {
+    // duraciones: 2h, 6h → mediana 4h
+    const events = [merged('1', 3, 1), merged('2', 8, 2)]
+    expect(medianMergeHours(events)).toBe(4)
   })
 })
 

--- a/src/__tests__/hooks/useTeamStats.test.ts
+++ b/src/__tests__/hooks/useTeamStats.test.ts
@@ -38,6 +38,26 @@ describe('aggregateEvents', () => {
     expect(aggregateEvents(events)).toHaveLength(0)
   })
 
+  it('excluye eventos fuera de la ventana por defecto (7 días)', () => {
+    const twentyDaysAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString()
+    const events = [makeEvent('1', 'alice', 'PushEvent', twentyDaysAgo, { commits: [{ sha: 'a', message: 'x' }] })]
+    expect(aggregateEvents(events)).toHaveLength(0)
+  })
+
+  it('incluye eventos de hace 20 días con ventana de 30', () => {
+    const twentyDaysAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString()
+    const events = [makeEvent('1', 'alice', 'PushEvent', twentyDaysAgo, { commits: [{ sha: 'a', message: 'x' }] })]
+    const result = aggregateEvents(events, 30)
+    expect(result).toHaveLength(1)
+    expect(result[0].commits).toBe(1)
+  })
+
+  it('dimensiona dailyCommits según la ventana', () => {
+    const events = [makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] })]
+    expect(aggregateEvents(events, 7)[0].dailyCommits).toHaveLength(7)
+    expect(aggregateEvents(events, 30)[0].dailyCommits).toHaveLength(30)
+  })
+
   it('cuenta PRs abiertos y mergeados por separado', () => {
     const events = [
       makeEvent('1', 'bob', 'PullRequestEvent', NOW, { action: 'opened' }),

--- a/src/__tests__/hooks/useTeamStats.test.ts
+++ b/src/__tests__/hooks/useTeamStats.test.ts
@@ -58,6 +58,25 @@ describe('aggregateEvents', () => {
     expect(aggregateEvents(events, 30)[0].dailyCommits).toHaveLength(30)
   })
 
+  it('NO crea developer para eventos que no son contribución (star/fork)', () => {
+    const events = [
+      makeEvent('1', 'randouser', 'WatchEvent', NOW, { action: 'started' }),
+      makeEvent('2', 'forker', 'ForkEvent', NOW, {}),
+      makeEvent('3', 'commenter', 'IssueCommentEvent', NOW, { action: 'created' }),
+    ]
+    expect(aggregateEvents(events)).toHaveLength(0)
+  })
+
+  it('excluye actores bot del roster', () => {
+    const events = [
+      makeEvent('1', 'dependabot[bot]', 'PullRequestEvent', NOW, { action: 'opened' }),
+      makeEvent('2', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].login).toBe('alice')
+  })
+
   it('cuenta PRs abiertos y mergeados por separado', () => {
     const events = [
       makeEvent('1', 'bob', 'PullRequestEvent', NOW, { action: 'opened' }),

--- a/src/__tests__/hooks/useTeamStats.test.ts
+++ b/src/__tests__/hooks/useTeamStats.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateEvents } from '../../hooks/useTeamStats'
+
+const NOW = new Date().toISOString()
+const OLD = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString() // 8 días atrás
+
+const makeEvent = (
+  id: string,
+  login: string,
+  type: string,
+  created_at: string,
+  payload: object = {}
+) => ({
+  id,
+  type,
+  actor: { login, avatar_url: `https://avatars.githubusercontent.com/u/1?v=4` },
+  created_at,
+  payload,
+})
+
+describe('aggregateEvents', () => {
+  it('cuenta commits de PushEvent de esta semana', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'fix' }, { sha: 'b', message: 'feat' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].login).toBe('alice')
+    expect(result[0].commits).toBe(2)
+  })
+
+  it('ignora eventos de hace más de 7 días', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', OLD, { commits: [{ sha: 'a', message: 'old' }] }),
+    ]
+    expect(aggregateEvents(events)).toHaveLength(0)
+  })
+
+  it('cuenta PRs abiertos y mergeados por separado', () => {
+    const events = [
+      makeEvent('1', 'bob', 'PullRequestEvent', NOW, { action: 'opened' }),
+      makeEvent('2', 'bob', 'PullRequestEvent', NOW, { action: 'closed', pull_request: { merged: true } }),
+      makeEvent('3', 'bob', 'PullRequestEvent', NOW, { action: 'closed', pull_request: { merged: false } }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].prsOpened).toBe(1)
+    expect(result[0].prsMerged).toBe(1)
+  })
+
+  it('cuenta issues cerrados', () => {
+    const events = [
+      makeEvent('1', 'carol', 'IssuesEvent', NOW, { action: 'closed' }),
+      makeEvent('2', 'carol', 'IssuesEvent', NOW, { action: 'opened' }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].issuesClosed).toBe(1)
+  })
+
+  it('agrupa múltiples eventos del mismo developer', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('2', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'b', message: 'y' }, { sha: 'c', message: 'z' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result).toHaveLength(1)
+    expect(result[0].commits).toBe(3)
+  })
+
+  it('ordena por commits descendente', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('2', 'bob', 'PushEvent', NOW, { commits: [{ sha: 'b', message: 'y' }, { sha: 'c', message: 'z' }, { sha: 'd', message: 'w' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].login).toBe('bob')
+    expect(result[1].login).toBe('alice')
+  })
+
+  it('deduplica eventos con el mismo id', () => {
+    const events = [
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+      makeEvent('1', 'alice', 'PushEvent', NOW, { commits: [{ sha: 'a', message: 'x' }] }),
+    ]
+    const result = aggregateEvents(events)
+    expect(result[0].commits).toBe(1)
+  })
+})

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -1,0 +1,134 @@
+import { useTeamStats } from '../hooks/useTeamStats'
+import type { PresenceState } from '../hooks/useTeamPresence'
+
+interface TeamStatsProps {
+  repos: Array<{ repo_full_name: string }>
+  githubToken: string | null
+  presence: Record<string, PresenceState>
+}
+
+function timeAgo(dateStr: string | null): string {
+  if (!dateStr) return '—'
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h`
+  return `${Math.floor(hrs / 24)}d`
+}
+
+export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
+  const { stats, loading, error } = useTeamStats(repos, githubToken)
+  const onlineCount = Object.keys(presence).length
+  const onlineLogins = new Set(
+    Object.values(presence).map(p => p.displayName.split('@')[0].toLowerCase())
+  )
+
+  if (!githubToken) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">Connect your GitHub account to see team stats</div>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">Loading stats…</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="ts-container">
+        <div className="ts-empty">{error}</div>
+      </div>
+    )
+  }
+
+  const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
+
+  return (
+    <div className="ts-container">
+      {/* Overview cards */}
+      <div>
+        <div className="ts-section-title">This week</div>
+        <div className="ts-overview-row">
+          <div className="ts-card">
+            <span className="ts-card-label">Online now</span>
+            <span className="ts-card-value">{onlineCount}</span>
+            <span className="ts-card-sub">developers active</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">Commits</span>
+            <span className="ts-card-value">{totalCommits}</span>
+            <span className="ts-card-sub">across all repos</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">PRs merged</span>
+            <span className="ts-card-value">{totalPrsMerged}</span>
+            <span className="ts-card-sub">this week</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">Top dev</span>
+            <span className="ts-card-value" style={{ fontSize: 14, paddingTop: 4 }}>
+              {topDeveloper ? `@${topDeveloper.login}` : '—'}
+            </span>
+            <span className="ts-card-sub">
+              {topDeveloper ? `${topDeveloper.commits} commits` : 'no activity'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Developer table */}
+      <div>
+        <div className="ts-section-title">Developers</div>
+        {developers.length === 0 ? (
+          <div className="ts-empty">No activity in the last 7 days</div>
+        ) : (
+          <div className="ts-table-wrap">
+            <table className="ts-table">
+              <thead>
+                <tr>
+                  <th>Developer</th>
+                  <th style={{ textAlign: 'right' }}>Commits</th>
+                  <th style={{ textAlign: 'right' }}>PRs</th>
+                  <th style={{ textAlign: 'right' }}>Issues</th>
+                  <th style={{ textAlign: 'right' }}>Last activity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {developers.map(dev => {
+                  const isOnline = onlineLogins.has(dev.login.toLowerCase())
+                  return (
+                    <tr key={dev.login}>
+                      <td>
+                        <div className="ts-dev-cell">
+                          <span className={`ts-status-dot ${isOnline ? 'online' : 'offline'}`} />
+                          <img
+                            className="ts-avatar"
+                            src={dev.avatarUrl}
+                            alt={dev.login}
+                          />
+                          <span>{dev.login}</span>
+                        </div>
+                      </td>
+                      <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num ts-muted">{timeAgo(dev.lastEventAt)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -19,21 +19,28 @@ function timeAgo(dateStr: string | null): string {
   return `${Math.floor(hrs / 24)}d`
 }
 
-function Sparkline({ data }: { data: number[] }) {
+function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
+  const W = 64, H = 26
   const max = Math.max(...data, 1)
+  const pts = data.map((v, i) => ({
+    x: (i / (data.length - 1)) * W,
+    y: H - Math.max(3, (v / max) * H),
+  }))
+  const line = pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')
+  const area = `${line} L${W},${H} L0,${H} Z`
+  const last = pts[pts.length - 1]
   return (
-    <div className="ts-sparkline">
-      {data.map((v, i) => (
-        <div
-          key={i}
-          className="ts-spark-bar"
-          style={{
-            height: `${Math.max(8, Math.round((v / max) * 100))}%`,
-            opacity: v > 0 ? 1 : 0.15,
-          }}
-        />
-      ))}
-    </div>
+    <svg className="ts-spark" width={W} height={H} viewBox={`0 0 ${W} ${H}`} fill="none">
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={area} fill={`url(#${gradId})`} />
+      <path d={line} stroke="#3b82f6" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={last.x} cy={last.y} r="2.5" fill="#3b82f6" />
+    </svg>
   )
 }
 
@@ -101,22 +108,22 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
       <div>
         <div className="ts-section-title">This week</div>
         <div className="ts-overview-row">
-          <div className="ts-card">
+          <div className="ts-card ts-card--green">
             <span className="ts-card-label">Online now</span>
             <span className="ts-card-value">{onlineCount}</span>
             <span className="ts-card-sub">developers active</span>
           </div>
-          <div className="ts-card">
+          <div className="ts-card ts-card--blue">
             <span className="ts-card-label">Commits</span>
             <span className="ts-card-value">{totalCommits}</span>
             <span className="ts-card-sub">across all repos</span>
           </div>
-          <div className="ts-card">
+          <div className="ts-card ts-card--purple">
             <span className="ts-card-label">PRs merged</span>
             <span className="ts-card-value">{totalPrsMerged}</span>
             <span className="ts-card-sub">this week</span>
           </div>
-          <div className="ts-card">
+          <div className="ts-card ts-card--amber">
             <span className="ts-card-label">Top dev</span>
             <span className="ts-card-value" style={{ fontSize: 14, paddingTop: 4 }}>
               {topDeveloper ? `@${topDeveloper.login}` : '—'}
@@ -167,12 +174,14 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                 </tr>
               </thead>
               <tbody>
-                {sortedDevs.map(dev => {
+                {sortedDevs.map((dev, i) => {
                   const isOnline = onlineLogins.has(dev.login.toLowerCase())
+                  const isTop = i === 0
                   return (
-                    <tr key={dev.login}>
+                    <tr key={dev.login} className={isTop ? 'ts-top-row' : undefined}>
                       <td>
                         <div className="ts-dev-cell">
+                          <span className="ts-rank">{i + 1}</span>
                           <span className={`ts-status-dot ${isOnline ? 'online' : 'offline'}`} />
                           <img
                             className="ts-avatar"
@@ -180,8 +189,8 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                             alt={dev.login}
                           />
                           <div className="ts-dev-info">
-                            <span>{dev.login}</span>
-                            <Sparkline data={dev.dailyCommits} />
+                            <span className="ts-dev-name">{dev.login}</span>
+                            <AreaSparkline data={dev.dailyCommits} gradId={`ts-sg-${dev.login}`} />
                           </div>
                         </div>
                       </td>

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -110,22 +110,23 @@ function TeamBarChart({ daily }: { daily: number[] }) {
   )
 }
 
-const MEDALS = ['🥇', '🥈', '🥉']
 function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> }) {
   const top = devs.slice(0, 3)
   if (top.length === 0) return null
   return (
     <div className="ts-podium">
       {top.map((dev, i) => (
-        <div key={dev.login} className={`ts-podium-card ts-podium-${i}`}>
-          <span className="ts-medal" aria-hidden>{MEDALS[i]}</span>
-          <img className="ts-podium-av" src={dev.avatarUrl} alt={dev.login} />
-          <span className="ts-podium-name">
-            <span className={`ts-status-dot ${online.has(dev.login.toLowerCase()) ? 'online' : 'offline'}`} />
-            {dev.login}
+        <div key={dev.login} className="ts-podium-row">
+          <span className="ts-podium-rank">{i + 1}</span>
+          <span className="ts-podium-av-wrap">
+            <img className="ts-podium-av" src={dev.avatarUrl} alt={dev.login} />
+            <span className={`ts-podium-dot ${online.has(dev.login.toLowerCase()) ? 'online' : 'offline'}`} />
           </span>
-          <span className="ts-podium-commits">{dev.commits} commits</span>
-          <span className="ts-podium-sub">{dev.prsMerged} PRs · {dev.issuesClosed} issues</span>
+          <span className="ts-podium-info">
+            <span className="ts-podium-name">{dev.login}</span>
+            <span className="ts-podium-sub">{dev.prsMerged} PRs · {dev.issuesClosed} issues</span>
+          </span>
+          <span className="ts-podium-commits">{dev.commits}<span className="ts-podium-unit">commits</span></span>
         </div>
       ))}
     </div>
@@ -268,22 +269,22 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           </div>
         </div>
         <div className="ts-overview-row">
-          <div className="ts-card ts-card--green">
+          <div className="ts-card">
             <span className="ts-card-label">Online now</span>
             <span className="ts-card-value">{onlineCount}</span>
             <span className="ts-card-sub">developers active</span>
           </div>
-          <div className="ts-card ts-card--blue">
+          <div className="ts-card">
             <span className="ts-card-label">Commits</span>
             <span className="ts-card-value">{totalCommits}</span>
             <span className="ts-card-sub">across all repos <DeltaBadge current={totalCommits} previous={prevCommits} /></span>
           </div>
-          <div className="ts-card ts-card--purple">
+          <div className="ts-card">
             <span className="ts-card-label">PRs merged</span>
             <span className="ts-card-value">{totalPrsMerged}</span>
             <span className="ts-card-sub">{windowDays === 7 ? 'this week' : 'this month'} <DeltaBadge current={totalPrsMerged} previous={prevPrsMerged} /></span>
           </div>
-          <div className="ts-card ts-card--amber">
+          <div className="ts-card">
             <span className="ts-card-label">Top dev</span>
             <span className="ts-card-value" style={{ fontSize: 14, paddingTop: 4 }}>
               {topDeveloper ? `@${topDeveloper.login}` : '—'}

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, memo, type CSSProperties } from 'react'
 import { useTeamStats, type DeveloperStats } from '../hooks/useTeamStats'
 import type { PresenceState } from '../hooks/useTeamPresence'
 
@@ -27,7 +27,7 @@ function timeAgo(dateStr: string | null): string {
   return `${Math.floor(hrs / 24)}d`
 }
 
-function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
+const AreaSparkline = memo(function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
   const W = 64, H = 26
   const max = Math.max(...data, 1)
   const pts = data.map((v, i) => ({
@@ -50,7 +50,7 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
       <circle cx={last.x} cy={last.y} r="2.5" fill="var(--ts-accent)" />
     </svg>
   )
-}
+})
 
 // ▲/▼ vs período anterior. Verde/rojo semánticos, nunca color solo (lleva flecha + %).
 function DeltaBadge({ current, previous }: { current: number; previous: number }) {
@@ -73,8 +73,17 @@ function dayLabel(daysAgo: number): string {
   return d.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric' })
 }
 
+// Alinea el tooltip al borde de la columna cuando está cerca de los extremos,
+// para que no se corte contra el borde del panel (peor en vista Month).
+function tipStyle(i: number, n: number): CSSProperties {
+  const Y = 'calc(-100% - 4px)'
+  if (i <= 1) return { left: 0, transform: `translateY(${Y})` }
+  if (i >= n - 2) return { right: 0, left: 'auto', transform: `translateY(${Y})` }
+  return { left: '50%', transform: `translate(-50%, ${Y})` }
+}
+
 // Actividad del equipo por día — una sola serie (azul de marca), con hover por barra.
-function TeamBarChart({ daily }: { daily: number[] }) {
+const TeamBarChart = memo(function TeamBarChart({ daily }: { daily: number[] }) {
   const [hover, setHover] = useState<number | null>(null)
   const n = daily.length
   const max = Math.max(...daily, 1)
@@ -91,7 +100,7 @@ function TeamBarChart({ daily }: { daily: number[] }) {
               onMouseEnter={() => setHover(i)}
             >
               {hover === i && (
-                <div className="ts-bar-tip">
+                <div className="ts-bar-tip" style={tipStyle(i, n)}>
                   <strong>{v}</strong> commit{v === 1 ? '' : 's'}
                   <span>{daysAgo === 0 ? 'today' : dayLabel(daysAgo)}</span>
                 </div>
@@ -108,9 +117,9 @@ function TeamBarChart({ daily }: { daily: number[] }) {
       </div>
     </div>
   )
-}
+})
 
-function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> }) {
+const Podium = memo(function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> }) {
   const top = devs.slice(0, 3)
   if (top.length === 0) return null
   return (
@@ -131,10 +140,10 @@ function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> 
       ))}
     </div>
   )
-}
+})
 
 // Matriz devs × días (quién trabajó cuándo). Secuencial de un solo hue (azul).
-function TeamHeatmap({ devs }: { devs: DeveloperStats[] }) {
+const TeamHeatmap = memo(function TeamHeatmap({ devs }: { devs: DeveloperStats[] }) {
   const rows = devs.slice(0, 8)
   if (rows.length === 0) return null
   const max = Math.max(1, ...rows.flatMap(d => d.dailyCommits))
@@ -165,7 +174,7 @@ function TeamHeatmap({ devs }: { devs: DeveloperStats[] }) {
       )}
     </div>
   )
-}
+})
 
 function StatsSkeleton() {
   return (
@@ -182,9 +191,9 @@ function StatsSkeleton() {
 
 export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
   const [windowDays, setWindowDays] = useState<7 | 30>(7)
-  const { stats, loading, error } = useTeamStats(repos, githubToken, windowDays)
+  const { stats, loading, error, warning } = useTeamStats(repos, githubToken, windowDays)
   const onlineCount = Object.keys(presence).length
-  const onlineLogins = onlineGithubLogins(presence)
+  const onlineLogins = useMemo(() => onlineGithubLogins(presence), [presence])
 
   type SortKey = 'commits' | 'prs' | 'issues'
   const [sortKey, setSortKey] = useState<SortKey>('commits')
@@ -249,6 +258,16 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
 
   return (
     <div className="ts-container">
+      {warning && (
+        <div className="ts-warning" role="status">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <path d="M8 1.5 15 14H1L8 1.5Z" strokeLinejoin="round" />
+            <path d="M8 6.5v3.5M8 12v.4" strokeLinecap="round" />
+          </svg>
+          {warning}
+        </div>
+      )}
+
       {/* Overview cards */}
       <div>
         <div className="ts-cards-header">

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
 import { useTeamStats } from '../hooks/useTeamStats'
-import type { RecentPR } from '../hooks/useTeamStats'
 import type { PresenceState } from '../hooks/useTeamPresence'
 
 interface TeamStatsProps {
@@ -82,7 +81,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     )
   }
 
-  const { developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs } = stats
+  const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
 
   const sortedDevs = useMemo(() => {
     return [...developers].sort((a, b) => {
@@ -140,7 +139,6 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
               <thead>
                 <tr>
                   <th>Developer</th>
-                  <th>Activity</th>
                   <th style={{ textAlign: 'right' }}>
                     <button className="ts-th-btn" onClick={() => handleSort('commits')}>
                       Commits
@@ -181,10 +179,12 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                             src={dev.avatarUrl}
                             alt={dev.login}
                           />
-                          <span>{dev.login}</span>
+                          <div className="ts-dev-info">
+                            <span>{dev.login}</span>
+                            <Sparkline data={dev.dailyCommits} />
+                          </div>
                         </div>
                       </td>
-                      <td><Sparkline data={dev.dailyCommits} /></td>
                       <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
@@ -198,25 +198,6 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
         )}
       </div>
 
-      {recentPrs.length > 0 && (
-        <div>
-          <div className="ts-section-title">Recent PRs merged</div>
-          <div className="ts-pr-feed">
-            {recentPrs.slice(0, 10).map((pr: RecentPR) => (
-              <div key={pr.id} className="ts-pr-item">
-                <img className="ts-avatar" src={pr.avatarUrl} alt={pr.login} />
-                <div className="ts-pr-meta">
-                  <span className="ts-pr-title">{pr.title}</span>
-                  <span className="ts-pr-sub">
-                    @{pr.login} · {pr.repo.split('/')[1] ?? pr.repo} · {timeAgo(pr.mergedAt)}
-                  </span>
-                </div>
-                <span className="ts-pr-merged-badge">merged</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -118,7 +118,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                         </div>
                       </td>
                       <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
-                      <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.prsOpened || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num ts-muted">{timeAgo(dev.lastEventAt)}</td>
                     </tr>

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -52,6 +52,19 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
   )
 }
 
+function StatsSkeleton() {
+  return (
+    <div className="ts-container" aria-busy="true" aria-label="Loading team stats">
+      <div className="ts-overview-row">
+        {[0, 1, 2, 3].map(i => <div key={i} className="ts-skeleton ts-skel-card" />)}
+      </div>
+      <div>
+        {[0, 1, 2, 3, 4].map(i => <div key={i} className="ts-skeleton ts-skel-row" />)}
+      </div>
+    </div>
+  )
+}
+
 export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
   const [windowDays, setWindowDays] = useState<7 | 30>(7)
   const { stats, loading, error } = useTeamStats(repos, githubToken, windowDays)
@@ -86,17 +99,19 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
   if (!githubToken) {
     return (
       <div className="ts-container">
-        <div className="ts-empty">Connect your GitHub account to see team stats</div>
+        <div className="ts-empty">
+          <svg className="ts-empty-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Z" />
+            <path d="M8 12h8M12 8v8" strokeLinecap="round" />
+          </svg>
+          Connect your GitHub account to see team stats
+        </div>
       </div>
     )
   }
 
   if (loading) {
-    return (
-      <div className="ts-container">
-        <div className="ts-empty">Loading stats…</div>
-      </div>
-    )
+    return <StatsSkeleton />
   }
 
   if (error) {

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -82,33 +82,53 @@ function tipStyle(i: number, n: number): CSSProperties {
   return { left: '50%', transform: `translate(-50%, ${Y})` }
 }
 
-// Actividad del equipo por día — una sola serie (azul de marca), con hover por barra.
+// Techo "redondo" (múltiplo de 4) para que los ticks 0 / mitad / techo sean enteros.
+function niceCeil(v: number): number {
+  return Math.max(4, Math.ceil(v / 4) * 4)
+}
+
+// Actividad del equipo por día — una sola serie (azul de marca). Barras finas con
+// tope redondeado, gridlines punteadas con escala, y HOY resaltado a azul pleno
+// (los demás días al 55% del mismo azul).
 const TeamBarChart = memo(function TeamBarChart({ daily }: { daily: number[] }) {
   const [hover, setHover] = useState<number | null>(null)
   const n = daily.length
-  const max = Math.max(...daily, 1)
+  const top = niceCeil(Math.max(...daily))
+  const ticks = [top, top / 2, 0]
   const total = daily.reduce((a, b) => a + b, 0)
   return (
     <div className="ts-chart">
-      <div className="ts-chart-bars" onMouseLeave={() => setHover(null)}>
-        {daily.map((v, i) => {
-          const daysAgo = n - 1 - i
-          return (
-            <div
-              key={i}
-              className={`ts-bar-col${hover === i ? ' hover' : ''}`}
-              onMouseEnter={() => setHover(i)}
-            >
-              {hover === i && (
-                <div className="ts-bar-tip" style={tipStyle(i, n)}>
-                  <strong>{v}</strong> commit{v === 1 ? '' : 's'}
-                  <span>{daysAgo === 0 ? 'today' : dayLabel(daysAgo)}</span>
+      <div className="ts-chart-plot">
+        <div className="ts-chart-axis">
+          {ticks.map(t => <span key={t}>{t}</span>)}
+        </div>
+        <div className="ts-chart-grid" onMouseLeave={() => setHover(null)}>
+          {ticks.map(t => <span key={t} className="ts-grid-line" style={{ bottom: `${(t / top) * 100}%` }} />)}
+          <div className="ts-chart-bars">
+            {daily.map((v, i) => {
+              const daysAgo = n - 1 - i
+              const isToday = daysAgo === 0
+              return (
+                <div
+                  key={i}
+                  className={`ts-bar-col${hover === i ? ' hover' : ''}`}
+                  onMouseEnter={() => setHover(i)}
+                >
+                  {hover === i && (
+                    <div className="ts-bar-tip" style={tipStyle(i, n)}>
+                      <strong>{v}</strong> commit{v === 1 ? '' : 's'}
+                      <span>{isToday ? 'today' : dayLabel(daysAgo)}</span>
+                    </div>
+                  )}
+                  <div
+                    className={`ts-bar${isToday ? ' today' : ''}`}
+                    style={{ height: `${(v / top) * 100}%` }}
+                  />
                 </div>
-              )}
-              <div className="ts-bar" style={{ height: `${Math.max(2, (v / max) * 100)}%` }} />
-            </div>
-          )
-        })}
+              )
+            })}
+          </div>
+        </div>
       </div>
       <div className="ts-chart-foot">
         <span>{dayLabel(n - 1)}</span>
@@ -119,28 +139,13 @@ const TeamBarChart = memo(function TeamBarChart({ daily }: { daily: number[] }) 
   )
 })
 
-const Podium = memo(function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> }) {
-  const top = devs.slice(0, 3)
-  if (top.length === 0) return null
-  return (
-    <div className="ts-podium">
-      {top.map((dev, i) => (
-        <div key={dev.login} className="ts-podium-row">
-          <span className="ts-podium-rank">{i + 1}</span>
-          <span className="ts-podium-av-wrap">
-            <img className="ts-podium-av" src={dev.avatarUrl} alt={dev.login} />
-            <span className={`ts-podium-dot ${online.has(dev.login.toLowerCase()) ? 'online' : 'offline'}`} />
-          </span>
-          <span className="ts-podium-info">
-            <span className="ts-podium-name">{dev.login}</span>
-            <span className="ts-podium-sub">{dev.prsMerged} PRs · {dev.issuesClosed} issues</span>
-          </span>
-          <span className="ts-podium-commits">{dev.commits}<span className="ts-podium-unit">commits</span></span>
-        </div>
-      ))}
-    </div>
-  )
-})
+// Formatea horas a una unidad legible: 40m / 6h / 2.3d.
+function fmtDuration(hours: number | null): string {
+  if (hours == null) return '—'
+  if (hours < 1) return `${Math.round(hours * 60)}m`
+  if (hours < 24) return `${Math.round(hours)}h`
+  return `${(hours / 24).toFixed(1)}d`
+}
 
 // Matriz devs × días (quién trabajó cuándo). Secuencial de un solo hue (azul).
 const TeamHeatmap = memo(function TeamHeatmap({ devs }: { devs: DeveloperStats[] }) {
@@ -180,7 +185,7 @@ function StatsSkeleton() {
   return (
     <div className="ts-container" aria-busy="true" aria-label="Loading team stats">
       <div className="ts-overview-row">
-        {[0, 1, 2, 3].map(i => <div key={i} className="ts-skeleton ts-skel-card" />)}
+        {[0, 1, 2, 3, 4, 5].map(i => <div key={i} className="ts-skeleton ts-skel-card" />)}
       </div>
       <div>
         {[0, 1, 2, 3, 4].map(i => <div key={i} className="ts-skeleton ts-skel-row" />)}
@@ -195,7 +200,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
   const onlineCount = Object.keys(presence).length
   const onlineLogins = useMemo(() => onlineGithubLogins(presence), [presence])
 
-  type SortKey = 'commits' | 'prs' | 'issues'
+  type SortKey = 'commits' | 'prs' | 'reviews' | 'issues'
   const [sortKey, setSortKey] = useState<SortKey>('commits')
   const [sortDir, setSortDir] = useState<'desc' | 'asc'>('desc')
 
@@ -208,15 +213,16 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     }
   }
 
+  const metric = (d: DeveloperStats, key: SortKey): number =>
+    key === 'commits' ? d.commits
+      : key === 'prs' ? d.prsOpened + d.prsMerged
+      : key === 'reviews' ? d.reviews
+      : d.issuesClosed
+
   const sortedDevs = useMemo(() => {
     return [...stats.developers].sort((a, b) => {
-      const va = sortKey === 'commits' ? a.commits
-        : sortKey === 'prs' ? a.prsOpened + a.prsMerged
-        : a.issuesClosed
-      const vb = sortKey === 'commits' ? b.commits
-        : sortKey === 'prs' ? b.prsOpened + b.prsMerged
-        : b.issuesClosed
-      return sortDir === 'desc' ? vb - va : va - vb
+      const diff = metric(b, sortKey) - metric(a, sortKey)
+      return sortDir === 'desc' ? diff : -diff
     })
   }, [stats.developers, sortKey, sortDir])
 
@@ -254,7 +260,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     )
   }
 
-  const { developers, totalCommits, totalPrsMerged, topDeveloper, prevCommits, prevPrsMerged } = stats
+  const { developers, totalCommits, totalPrsMerged, totalReviews, mergeTimeHours, topDeveloper, prevCommits, prevPrsMerged } = stats
 
   return (
     <div className="ts-container">
@@ -304,6 +310,16 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
             <span className="ts-card-sub">{windowDays === 7 ? 'this week' : 'this month'} <DeltaBadge current={totalPrsMerged} previous={prevPrsMerged} /></span>
           </div>
           <div className="ts-card">
+            <span className="ts-card-label">Reviews</span>
+            <span className="ts-card-value">{totalReviews}</span>
+            <span className="ts-card-sub">PRs reviewed by the team</span>
+          </div>
+          <div className="ts-card">
+            <span className="ts-card-label">PR merge time</span>
+            <span className="ts-card-value">{fmtDuration(mergeTimeHours)}</span>
+            <span className="ts-card-sub">median, open → merge</span>
+          </div>
+          <div className="ts-card">
             <span className="ts-card-label">Top dev</span>
             <span className="ts-card-value" style={{ fontSize: 14, paddingTop: 4 }}>
               {topDeveloper ? `@${topDeveloper.login}` : '—'}
@@ -320,14 +336,6 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
         <div>
           <div className="ts-section-title">Team activity — commits per day</div>
           <TeamBarChart daily={teamDaily} />
-        </div>
-      )}
-
-      {/* Top performers podium */}
-      {developers.length > 0 && (
-        <div>
-          <div className="ts-section-title">Top performers</div>
-          <Podium devs={developers} online={onlineLogins} />
         </div>
       )}
 
@@ -355,6 +363,14 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                       PRs
                       <span className={`ts-sort-icon${sortKey === 'prs' ? ' active' : ''}`}>
                         {sortKey === 'prs' ? (sortDir === 'desc' ? '↓' : '↑') : '↕'}
+                      </span>
+                    </button>
+                  </th>
+                  <th style={{ textAlign: 'right' }}>
+                    <button className="ts-th-btn" onClick={() => handleSort('reviews')}>
+                      Reviews
+                      <span className={`ts-sort-icon${sortKey === 'reviews' ? ' active' : ''}`}>
+                        {sortKey === 'reviews' ? (sortDir === 'desc' ? '↓' : '↑') : '↕'}
                       </span>
                     </button>
                   </th>
@@ -392,6 +408,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                       </td>
                       <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.reviews || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num ts-muted">{timeAgo(dev.lastEventAt)}</td>
                     </tr>

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -64,6 +64,18 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     }
   }
 
+  const sortedDevs = useMemo(() => {
+    return [...stats.developers].sort((a, b) => {
+      const va = sortKey === 'commits' ? a.commits
+        : sortKey === 'prs' ? a.prsOpened + a.prsMerged
+        : a.issuesClosed
+      const vb = sortKey === 'commits' ? b.commits
+        : sortKey === 'prs' ? b.prsOpened + b.prsMerged
+        : b.issuesClosed
+      return sortDir === 'desc' ? vb - va : va - vb
+    })
+  }, [stats.developers, sortKey, sortDir])
+
   if (!githubToken) {
     return (
       <div className="ts-container">
@@ -89,18 +101,6 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
   }
 
   const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
-
-  const sortedDevs = useMemo(() => {
-    return [...developers].sort((a, b) => {
-      const va = sortKey === 'commits' ? a.commits
-        : sortKey === 'prs' ? a.prsOpened + a.prsMerged
-        : a.issuesClosed
-      const vb = sortKey === 'commits' ? b.commits
-        : sortKey === 'prs' ? b.prsOpened + b.prsMerged
-        : b.issuesClosed
-      return sortDir === 'desc' ? vb - va : va - vb
-    })
-  }, [developers, sortKey, sortDir])
 
   return (
     <div className="ts-container">

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -118,7 +118,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                         </div>
                       </td>
                       <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
-                      <td className="ts-num">{dev.prsOpened || <span className="ts-muted">—</span>}</td>
+                      <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num ts-muted">{timeAgo(dev.lastEventAt)}</td>
                     </tr>

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -8,6 +8,14 @@ interface TeamStatsProps {
   presence: Record<string, PresenceState>
 }
 
+export function onlineGithubLogins(presence: Record<string, PresenceState>): Set<string> {
+  const set = new Set<string>()
+  for (const p of Object.values(presence)) {
+    if (p.githubLogin) set.add(p.githubLogin.toLowerCase())
+  }
+  return set
+}
+
 function timeAgo(dateStr: string | null): string {
   if (!dateStr) return '—'
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -47,9 +55,7 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
 export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
   const { stats, loading, error } = useTeamStats(repos, githubToken)
   const onlineCount = Object.keys(presence).length
-  const onlineLogins = new Set(
-    Object.values(presence).map(p => p.displayName.split('@')[0].toLowerCase())
-  )
+  const onlineLogins = onlineGithubLogins(presence)
 
   type SortKey = 'commits' | 'prs' | 'issues'
   const [sortKey, setSortKey] = useState<SortKey>('commits')

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -1,4 +1,6 @@
+import { useState, useMemo } from 'react'
 import { useTeamStats } from '../hooks/useTeamStats'
+import type { RecentPR } from '../hooks/useTeamStats'
 import type { PresenceState } from '../hooks/useTeamPresence'
 
 interface TeamStatsProps {
@@ -18,12 +20,43 @@ function timeAgo(dateStr: string | null): string {
   return `${Math.floor(hrs / 24)}d`
 }
 
+function Sparkline({ data }: { data: number[] }) {
+  const max = Math.max(...data, 1)
+  return (
+    <div className="ts-sparkline">
+      {data.map((v, i) => (
+        <div
+          key={i}
+          className="ts-spark-bar"
+          style={{
+            height: `${Math.max(8, Math.round((v / max) * 100))}%`,
+            opacity: v > 0 ? 1 : 0.15,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
 export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
   const { stats, loading, error } = useTeamStats(repos, githubToken)
   const onlineCount = Object.keys(presence).length
   const onlineLogins = new Set(
     Object.values(presence).map(p => p.displayName.split('@')[0].toLowerCase())
   )
+
+  type SortKey = 'commits' | 'prs' | 'issues'
+  const [sortKey, setSortKey] = useState<SortKey>('commits')
+  const [sortDir, setSortDir] = useState<'desc' | 'asc'>('desc')
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(d => d === 'desc' ? 'asc' : 'desc')
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
 
   if (!githubToken) {
     return (
@@ -49,7 +82,19 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     )
   }
 
-  const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
+  const { developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs } = stats
+
+  const sortedDevs = useMemo(() => {
+    return [...developers].sort((a, b) => {
+      const va = sortKey === 'commits' ? a.commits
+        : sortKey === 'prs' ? a.prsOpened + a.prsMerged
+        : a.issuesClosed
+      const vb = sortKey === 'commits' ? b.commits
+        : sortKey === 'prs' ? b.prsOpened + b.prsMerged
+        : b.issuesClosed
+      return sortDir === 'desc' ? vb - va : va - vb
+    })
+  }, [developers, sortKey, sortDir])
 
   return (
     <div className="ts-container">
@@ -95,14 +140,36 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
               <thead>
                 <tr>
                   <th>Developer</th>
-                  <th style={{ textAlign: 'right' }}>Commits</th>
-                  <th style={{ textAlign: 'right' }}>PRs</th>
-                  <th style={{ textAlign: 'right' }}>Issues</th>
+                  <th>Activity</th>
+                  <th style={{ textAlign: 'right' }}>
+                    <button className="ts-th-btn" onClick={() => handleSort('commits')}>
+                      Commits
+                      <span className={`ts-sort-icon${sortKey === 'commits' ? ' active' : ''}`}>
+                        {sortKey === 'commits' ? (sortDir === 'desc' ? '↓' : '↑') : '↕'}
+                      </span>
+                    </button>
+                  </th>
+                  <th style={{ textAlign: 'right' }}>
+                    <button className="ts-th-btn" onClick={() => handleSort('prs')}>
+                      PRs
+                      <span className={`ts-sort-icon${sortKey === 'prs' ? ' active' : ''}`}>
+                        {sortKey === 'prs' ? (sortDir === 'desc' ? '↓' : '↑') : '↕'}
+                      </span>
+                    </button>
+                  </th>
+                  <th style={{ textAlign: 'right' }}>
+                    <button className="ts-th-btn" onClick={() => handleSort('issues')}>
+                      Issues
+                      <span className={`ts-sort-icon${sortKey === 'issues' ? ' active' : ''}`}>
+                        {sortKey === 'issues' ? (sortDir === 'desc' ? '↓' : '↑') : '↕'}
+                      </span>
+                    </button>
+                  </th>
                   <th style={{ textAlign: 'right' }}>Last activity</th>
                 </tr>
               </thead>
               <tbody>
-                {developers.map(dev => {
+                {sortedDevs.map(dev => {
                   const isOnline = onlineLogins.has(dev.login.toLowerCase())
                   return (
                     <tr key={dev.login}>
@@ -117,6 +184,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
                           <span>{dev.login}</span>
                         </div>
                       </td>
+                      <td><Sparkline data={dev.dailyCommits} /></td>
                       <td className="ts-num">{dev.commits || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.prsOpened + dev.prsMerged || <span className="ts-muted">—</span>}</td>
                       <td className="ts-num">{dev.issuesClosed || <span className="ts-muted">—</span>}</td>
@@ -129,6 +197,26 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           </div>
         )}
       </div>
+
+      {recentPrs.length > 0 && (
+        <div>
+          <div className="ts-section-title">Recent PRs merged</div>
+          <div className="ts-pr-feed">
+            {recentPrs.slice(0, 10).map((pr: RecentPR) => (
+              <div key={pr.id} className="ts-pr-item">
+                <img className="ts-avatar" src={pr.avatarUrl} alt={pr.login} />
+                <div className="ts-pr-meta">
+                  <span className="ts-pr-title">{pr.title}</span>
+                  <span className="ts-pr-sub">
+                    @{pr.login} · {pr.repo.split('/')[1] ?? pr.repo} · {timeAgo(pr.mergedAt)}
+                  </span>
+                </div>
+                <span className="ts-pr-merged-badge">merged</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -53,7 +53,8 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
 }
 
 export default function TeamStats({ repos, githubToken, presence }: TeamStatsProps) {
-  const { stats, loading, error } = useTeamStats(repos, githubToken)
+  const [windowDays, setWindowDays] = useState<7 | 30>(7)
+  const { stats, loading, error } = useTeamStats(repos, githubToken, windowDays)
   const onlineCount = Object.keys(presence).length
   const onlineLogins = onlineGithubLogins(presence)
 
@@ -112,7 +113,23 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     <div className="ts-container">
       {/* Overview cards */}
       <div>
-        <div className="ts-section-title">This week</div>
+        <div className="ts-cards-header">
+          <div className="ts-section-title">{windowDays === 7 ? 'This week' : 'This month'}</div>
+          <div className="ts-toggle" role="tablist" aria-label="Time period">
+            <button
+              role="tab"
+              aria-selected={windowDays === 7}
+              className={`ts-toggle-btn${windowDays === 7 ? ' active' : ''}`}
+              onClick={() => setWindowDays(7)}
+            >Week</button>
+            <button
+              role="tab"
+              aria-selected={windowDays === 30}
+              className={`ts-toggle-btn${windowDays === 30 ? ' active' : ''}`}
+              onClick={() => setWindowDays(30)}
+            >Month</button>
+          </div>
+        </div>
         <div className="ts-overview-row">
           <div className="ts-card ts-card--green">
             <span className="ts-card-label">Online now</span>
@@ -127,7 +144,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           <div className="ts-card ts-card--purple">
             <span className="ts-card-label">PRs merged</span>
             <span className="ts-card-value">{totalPrsMerged}</span>
-            <span className="ts-card-sub">this week</span>
+            <span className="ts-card-sub">{windowDays === 7 ? 'this week' : 'this month'}</span>
           </div>
           <div className="ts-card ts-card--amber">
             <span className="ts-card-label">Top dev</span>
@@ -145,7 +162,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
       <div>
         <div className="ts-section-title">Developers</div>
         {developers.length === 0 ? (
-          <div className="ts-empty">No activity in the last 7 days</div>
+          <div className="ts-empty">{`No activity in the last ${windowDays} days`}</div>
         ) : (
           <div className="ts-table-wrap">
             <table className="ts-table">

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -41,13 +41,13 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
     <svg className="ts-spark" width={W} height={H} viewBox={`0 0 ${W} ${H}`} fill="none">
       <defs>
         <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.25" />
-          <stop offset="100%" stopColor="#3b82f6" stopOpacity="0" />
+          <stop offset="0%" stopColor="var(--ts-accent)" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="var(--ts-accent)" stopOpacity="0" />
         </linearGradient>
       </defs>
       <path d={area} fill={`url(#${gradId})`} />
-      <path d={line} stroke="#3b82f6" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <circle cx={last.x} cy={last.y} r="2.5" fill="#3b82f6" />
+      <path d={line} stroke="var(--ts-accent)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={last.x} cy={last.y} r="2.5" fill="var(--ts-accent)" />
     </svg>
   )
 }

--- a/src/components/TeamStats.tsx
+++ b/src/components/TeamStats.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react'
-import { useTeamStats } from '../hooks/useTeamStats'
+import { useTeamStats, type DeveloperStats } from '../hooks/useTeamStats'
 import type { PresenceState } from '../hooks/useTeamPresence'
 
 interface TeamStatsProps {
@@ -52,6 +52,120 @@ function AreaSparkline({ data, gradId }: { data: number[]; gradId: string }) {
   )
 }
 
+// ▲/▼ vs período anterior. Verde/rojo semánticos, nunca color solo (lleva flecha + %).
+function DeltaBadge({ current, previous }: { current: number; previous: number }) {
+  if (previous === 0) {
+    if (current === 0) return null
+    return <span className="ts-delta up" title="Sin actividad en el período anterior">▲ nuevo</span>
+  }
+  const pct = Math.round(((current - previous) / previous) * 100)
+  if (pct === 0) return <span className="ts-delta flat">— 0%</span>
+  const up = pct > 0
+  return (
+    <span className={`ts-delta ${up ? 'up' : 'down'}`} title={`${current} vs ${previous} en el período anterior`}>
+      {up ? '▲' : '▼'} {Math.abs(pct)}%
+    </span>
+  )
+}
+
+function dayLabel(daysAgo: number): string {
+  const d = new Date(Date.now() - daysAgo * 86_400_000)
+  return d.toLocaleDateString('en-US', { weekday: 'short', day: 'numeric' })
+}
+
+// Actividad del equipo por día — una sola serie (azul de marca), con hover por barra.
+function TeamBarChart({ daily }: { daily: number[] }) {
+  const [hover, setHover] = useState<number | null>(null)
+  const n = daily.length
+  const max = Math.max(...daily, 1)
+  const total = daily.reduce((a, b) => a + b, 0)
+  return (
+    <div className="ts-chart">
+      <div className="ts-chart-bars" onMouseLeave={() => setHover(null)}>
+        {daily.map((v, i) => {
+          const daysAgo = n - 1 - i
+          return (
+            <div
+              key={i}
+              className={`ts-bar-col${hover === i ? ' hover' : ''}`}
+              onMouseEnter={() => setHover(i)}
+            >
+              {hover === i && (
+                <div className="ts-bar-tip">
+                  <strong>{v}</strong> commit{v === 1 ? '' : 's'}
+                  <span>{daysAgo === 0 ? 'today' : dayLabel(daysAgo)}</span>
+                </div>
+              )}
+              <div className="ts-bar" style={{ height: `${Math.max(2, (v / max) * 100)}%` }} />
+            </div>
+          )
+        })}
+      </div>
+      <div className="ts-chart-foot">
+        <span>{dayLabel(n - 1)}</span>
+        <span className="ts-chart-total">{total} commits en el período</span>
+        <span>today</span>
+      </div>
+    </div>
+  )
+}
+
+const MEDALS = ['🥇', '🥈', '🥉']
+function Podium({ devs, online }: { devs: DeveloperStats[]; online: Set<string> }) {
+  const top = devs.slice(0, 3)
+  if (top.length === 0) return null
+  return (
+    <div className="ts-podium">
+      {top.map((dev, i) => (
+        <div key={dev.login} className={`ts-podium-card ts-podium-${i}`}>
+          <span className="ts-medal" aria-hidden>{MEDALS[i]}</span>
+          <img className="ts-podium-av" src={dev.avatarUrl} alt={dev.login} />
+          <span className="ts-podium-name">
+            <span className={`ts-status-dot ${online.has(dev.login.toLowerCase()) ? 'online' : 'offline'}`} />
+            {dev.login}
+          </span>
+          <span className="ts-podium-commits">{dev.commits} commits</span>
+          <span className="ts-podium-sub">{dev.prsMerged} PRs · {dev.issuesClosed} issues</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Matriz devs × días (quién trabajó cuándo). Secuencial de un solo hue (azul).
+function TeamHeatmap({ devs }: { devs: DeveloperStats[] }) {
+  const rows = devs.slice(0, 8)
+  if (rows.length === 0) return null
+  const max = Math.max(1, ...rows.flatMap(d => d.dailyCommits))
+  const n = rows[0].dailyCommits.length
+  return (
+    <div className="ts-heatmap">
+      {rows.map(dev => (
+        <div key={dev.login} className="ts-heat-row">
+          <span className="ts-heat-name">{dev.login}</span>
+          <div className="ts-heat-cells" style={{ gridTemplateColumns: `repeat(${n}, 1fr)` }}>
+            {dev.dailyCommits.map((v, i) => {
+              const daysAgo = n - 1 - i
+              const alpha = v <= 0 ? 0 : 0.15 + 0.85 * (v / max)
+              return (
+                <div
+                  key={i}
+                  className="ts-heat-cell"
+                  style={v > 0 ? { background: `rgba(0,102,255,${alpha.toFixed(2)})` } : undefined}
+                  title={`${dev.login} — ${v} commit${v === 1 ? '' : 's'} ${daysAgo === 0 ? 'today' : `${daysAgo}d ago`}`}
+                />
+              )
+            })}
+          </div>
+        </div>
+      ))}
+      {devs.length > rows.length && (
+        <div className="ts-heat-more">+{devs.length - rows.length} developers más</div>
+      )}
+    </div>
+  )
+}
+
 function StatsSkeleton() {
   return (
     <div className="ts-container" aria-busy="true" aria-label="Loading team stats">
@@ -96,6 +210,14 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     })
   }, [stats.developers, sortKey, sortDir])
 
+  // Commits del equipo por día = suma de los dailyCommits de cada dev.
+  const teamDaily = useMemo(() => {
+    const n = stats.developers[0]?.dailyCommits.length ?? windowDays
+    const out = Array<number>(n).fill(0)
+    for (const d of stats.developers) d.dailyCommits.forEach((c, i) => { out[i] += c })
+    return out
+  }, [stats.developers, windowDays])
+
   if (!githubToken) {
     return (
       <div className="ts-container">
@@ -122,7 +244,7 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
     )
   }
 
-  const { developers, totalCommits, totalPrsMerged, topDeveloper } = stats
+  const { developers, totalCommits, totalPrsMerged, topDeveloper, prevCommits, prevPrsMerged } = stats
 
   return (
     <div className="ts-container">
@@ -154,12 +276,12 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           <div className="ts-card ts-card--blue">
             <span className="ts-card-label">Commits</span>
             <span className="ts-card-value">{totalCommits}</span>
-            <span className="ts-card-sub">across all repos</span>
+            <span className="ts-card-sub">across all repos <DeltaBadge current={totalCommits} previous={prevCommits} /></span>
           </div>
           <div className="ts-card ts-card--purple">
             <span className="ts-card-label">PRs merged</span>
             <span className="ts-card-value">{totalPrsMerged}</span>
-            <span className="ts-card-sub">{windowDays === 7 ? 'this week' : 'this month'}</span>
+            <span className="ts-card-sub">{windowDays === 7 ? 'this week' : 'this month'} <DeltaBadge current={totalPrsMerged} previous={prevPrsMerged} /></span>
           </div>
           <div className="ts-card ts-card--amber">
             <span className="ts-card-label">Top dev</span>
@@ -172,6 +294,22 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           </div>
         </div>
       </div>
+
+      {/* Team activity chart */}
+      {developers.length > 0 && (
+        <div>
+          <div className="ts-section-title">Team activity — commits per day</div>
+          <TeamBarChart daily={teamDaily} />
+        </div>
+      )}
+
+      {/* Top performers podium */}
+      {developers.length > 0 && (
+        <div>
+          <div className="ts-section-title">Top performers</div>
+          <Podium devs={developers} online={onlineLogins} />
+        </div>
+      )}
 
       {/* Developer table */}
       <div>
@@ -244,6 +382,14 @@ export default function TeamStats({ repos, githubToken, presence }: TeamStatsPro
           </div>
         )}
       </div>
+
+      {/* Activity matrix — who worked when */}
+      {developers.length > 0 && (
+        <div>
+          <div className="ts-section-title">Activity matrix — who worked when</div>
+          <TeamHeatmap devs={developers} />
+        </div>
+      )}
 
     </div>
   )

--- a/src/components/TeamsWorkspace.tsx
+++ b/src/components/TeamsWorkspace.tsx
@@ -363,8 +363,9 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
       label: 'Members',
       icon: <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="6" cy="5" r="2" stroke="currentColor" strokeWidth="1.3"/><path d="M2 13c0-2.21 1.79-4 4-4s4 1.79 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/><circle cx="11.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.2" opacity="0.7"/><path d="M13.5 12.5c0-1.38-.9-2.55-2.14-2.87" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" opacity="0.7"/></svg>,
     },
-    {
-      id: 'stats',
+    // Stats es solo para líderes/managers del team — no lo ven los miembros.
+    ...(isTeamLeader ? [{
+      id: 'stats' as WorkspaceSection,
       label: 'Stats',
       icon: (
         <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -373,7 +374,7 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
           <rect x="11" y="2" width="3" height="12" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
         </svg>
       ),
-    },
+    }] : []),
     {
       id: 'snippets',
       label: 'Snippets',
@@ -1300,7 +1301,9 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
               )}
 
               {/* STATS */}
-              {!creatingTeam && section === 'stats' && (
+              {/* Defensa en profundidad: solo líderes renderizan Stats, aunque
+                  el tab ya está oculto para miembros en NAV_ITEMS. */}
+              {!creatingTeam && section === 'stats' && isTeamLeader && (
                 <TeamStats
                   repos={repos.map(r => ({ repo_full_name: r.repo_full_name }))}
                   githubToken={githubToken}

--- a/src/components/TeamsWorkspace.tsx
+++ b/src/components/TeamsWorkspace.tsx
@@ -30,6 +30,7 @@ import { safeWriteText } from '../lib/clipboard'
 import ErrorBoundary from './ErrorBoundary'
 import JoinByCodeForm from './JoinByCodeForm'
 import TeamJoinCodePanel from './TeamJoinCodePanel'
+import TeamStats from './TeamStats'
 
 interface TeamsWorkspaceProps {
   onClose: () => void
@@ -41,7 +42,7 @@ interface TeamsWorkspaceProps {
   onStartTutorial?: () => void
 }
 
-type WorkspaceSection = 'activity' | 'chat' | 'repos' | 'issues' | 'members' | 'snippets' | 'workspaces' | 'mcp' | 'pendings'
+type WorkspaceSection = 'activity' | 'chat' | 'repos' | 'issues' | 'members' | 'stats' | 'snippets' | 'workspaces' | 'mcp' | 'pendings'
 type ReposView = 'list' | 'prs' | 'pr-detail'
 type IssuesView = 'repo-select' | 'list' | 'detail'
 
@@ -361,6 +362,17 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
       id: 'members',
       label: 'Members',
       icon: <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="6" cy="5" r="2" stroke="currentColor" strokeWidth="1.3"/><path d="M2 13c0-2.21 1.79-4 4-4s4 1.79 4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/><circle cx="11.5" cy="5.5" r="1.5" stroke="currentColor" strokeWidth="1.2" opacity="0.7"/><path d="M13.5 12.5c0-1.38-.9-2.55-2.14-2.87" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" opacity="0.7"/></svg>,
+    },
+    {
+      id: 'stats',
+      label: 'Stats',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+          <rect x="1" y="9" width="3" height="5" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+          <rect x="6" y="5" width="3" height="9" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+          <rect x="11" y="2" width="3" height="12" rx="0.5" stroke="currentColor" strokeWidth="1.3"/>
+        </svg>
+      ),
     },
     {
       id: 'snippets',
@@ -1285,6 +1297,15 @@ export default function TeamsWorkspace({ onClose, onLoad, onOpenRepoTerminal, on
                     ))}
                   </div>
                 </div>
+              )}
+
+              {/* STATS */}
+              {!creatingTeam && section === 'stats' && (
+                <TeamStats
+                  repos={repos.map(r => ({ repo_full_name: r.repo_full_name }))}
+                  githubToken={githubToken}
+                  presence={presence}
+                />
               )}
               </></ErrorBoundary>
 

--- a/src/hooks/useTeamPresence.ts
+++ b/src/hooks/useTeamPresence.ts
@@ -5,9 +5,38 @@ import { supabase } from '../lib/supabase'
 export interface PresenceState {
   userId: string
   displayName: string  // email o nombre
+  githubLogin: string | null
   repo: string | null
   branch: string | null
   lastSeen: string
+}
+
+// Arma el payload de presencia incluyendo el github_login real del perfil,
+// para que Stats pueda matchear "online" contra el login de GitHub del dev
+// (antes se adivinaba por el prefijo del email y casi nunca coincidía).
+async function buildPresencePayload(
+  currentUserId: string,
+  repo: string | null,
+  branch: string | null,
+): Promise<PresenceState> {
+  const { data: { user } } = await supabase.auth.getUser()
+  let githubLogin: string | null = null
+  if (user) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('github_login')
+      .eq('id', user.id)
+      .maybeSingle()
+    githubLogin = data?.github_login ?? null
+  }
+  return {
+    userId: currentUserId,
+    displayName: user?.email ?? currentUserId,
+    githubLogin,
+    repo,
+    branch,
+    lastSeen: new Date().toISOString(),
+  }
 }
 
 export function useTeamPresence(teamId: string | null, currentUserId: string | null) {
@@ -36,14 +65,7 @@ export function useTeamPresence(teamId: string | null, currentUserId: string | n
       })
       .subscribe(async (status) => {
         if (status === 'SUBSCRIBED') {
-          const { data: { user } } = await supabase.auth.getUser()
-          await channel.track({
-            userId: currentUserId,
-            displayName: user?.email ?? currentUserId,
-            repo: null,
-            branch: null,
-            lastSeen: new Date().toISOString(),
-          })
+          await channel.track(await buildPresencePayload(currentUserId, null, null))
         }
       })
 
@@ -65,14 +87,7 @@ export function useTeamPresence(teamId: string | null, currentUserId: string | n
     if (!teamId || !currentUserId) return
     const channel = channelRef.current
     if (!channel) return
-    const { data: { user } } = await supabase.auth.getUser()
-    await channel.track({
-      userId: currentUserId,
-      displayName: user?.email ?? currentUserId,
-      repo,
-      branch,
-      lastSeen: new Date().toISOString(),
-    })
+    await channel.track(await buildPresencePayload(currentUserId, repo, branch))
   }, [teamId, currentUserId])
 
   return { presence, updatePresence }

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -6,6 +6,7 @@ export interface DeveloperStats {
   commits: number
   prsOpened: number
   prsMerged: number
+  reviews: number          // PR reviews que ESTE dev le hizo a otros (PullRequestReviewEvent)
   issuesClosed: number
   lastEventAt: string | null
   dailyCommits: number[]   // 7 elements, index 0 = 6 days ago, index 6 = today
@@ -24,6 +25,9 @@ export interface TeamStatsData {
   developers: DeveloperStats[]
   totalCommits: number
   totalPrsMerged: number
+  totalReviews: number
+  /** Mediana de horas abierto→merge de los PRs mergeados en la ventana. null si no hubo. */
+  mergeTimeHours: number | null
   topDeveloper: DeveloperStats | null
   recentPrs: RecentPR[]
   /** Totales del período INMEDIATAMENTE anterior (misma duración), para deltas. */
@@ -40,7 +44,9 @@ interface GitHubEvent {
   payload: {
     action?: string
     commits?: { sha: string; message: string }[]
-    pull_request?: { merged?: boolean; title?: string }
+    // created_at/merged_at vienen en el objeto pull_request del Events API, sirven
+    // para medir el tiempo abierto→merge sin llamadas extra.
+    pull_request?: { merged?: boolean; title?: string; created_at?: string; merged_at?: string }
   }
 }
 
@@ -52,7 +58,7 @@ const MAX_DAYS = 60
 const CONCURRENCY = 5
 // Solo estos tipos de evento cuentan como "contribución" y crean una fila de developer.
 // Sin esto, un WatchEvent/ForkEvent/comentario mete gente que no commiteó al roster.
-const CONTRIB_TYPES = new Set(['PushEvent', 'PullRequestEvent', 'IssuesEvent'])
+const CONTRIB_TYPES = new Set(['PushEvent', 'PullRequestEvent', 'PullRequestReviewEvent', 'IssuesEvent'])
 const isBot = (login: string): boolean => login.endsWith('[bot]')
 
 function isWithinWindow(dateStr: string, windowDays: number): boolean {
@@ -80,6 +86,7 @@ export function aggregateEvents(events: GitHubEvent[], windowDays = 7): Develope
         commits: 0,
         prsOpened: 0,
         prsMerged: 0,
+        reviews: 0,
         issuesClosed: 0,
         lastEventAt: null,
         dailyCommits: Array(windowDays).fill(0),
@@ -99,6 +106,8 @@ export function aggregateEvents(events: GitHubEvent[], windowDays = 7): Develope
     } else if (event.type === 'PullRequestEvent') {
       if (event.payload.action === 'opened') dev.prsOpened++
       if (event.payload.action === 'closed' && event.payload.pull_request?.merged) dev.prsMerged++
+    } else if (event.type === 'PullRequestReviewEvent') {
+      if (event.payload.action === 'created') dev.reviews++
     } else if (event.type === 'IssuesEvent' && event.payload.action === 'closed') {
       dev.issuesClosed++
     }
@@ -130,6 +139,31 @@ export function extractRecentPrs(events: GitHubEvent[], windowDays = 7): RecentP
   }
 
   return prs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt))
+}
+
+/**
+ * Mediana de horas abierto→merge de los PRs mergeados dentro de la ventana.
+ * Usa created_at/merged_at del payload del Events API (sin llamadas extra).
+ * Mediana en vez de promedio: un PR viejo de días no distorsiona el número.
+ * Devuelve null si ningún PR mergeado trae ambas fechas.
+ */
+export function medianMergeHours(events: GitHubEvent[], windowDays = 7): number | null {
+  const seen = new Set<string>()
+  const durs: number[] = []
+  for (const event of events) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    if (!isWithinWindow(event.created_at, windowDays)) continue
+    if (event.type !== 'PullRequestEvent' || event.payload.action !== 'closed') continue
+    const pr = event.payload.pull_request
+    if (!pr?.merged || !pr.created_at || !pr.merged_at) continue
+    const h = (new Date(pr.merged_at).getTime() - new Date(pr.created_at).getTime()) / 3_600_000
+    if (h >= 0) durs.push(h)
+  }
+  if (durs.length === 0) return null
+  durs.sort((a, b) => a - b)
+  const mid = Math.floor(durs.length / 2)
+  return durs.length % 2 ? durs[mid] : (durs[mid - 1] + durs[mid]) / 2
 }
 
 /** Suma commits y PRs mergeados en la ventana [fromDaysAgo, toDaysAgo) (días atrás). */
@@ -252,13 +286,16 @@ export function useTeamStats(
   const developers = useMemo(() => aggregateEvents(events, windowDays), [events, windowDays])
   const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
   const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
+  const totalReviews = developers.reduce((s, d) => s + d.reviews, 0)
   const topDeveloper = developers[0] ?? null
   const recentPrs = useMemo(() => extractRecentPrs(events, windowDays), [events, windowDays])
+  const mergeTimeHours = useMemo(() => medianMergeHours(events, windowDays), [events, windowDays])
   const prev = useMemo(() => windowTotals(events, windowDays, windowDays * 2), [events, windowDays])
 
   return {
     stats: {
-      developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs,
+      developers, totalCommits, totalPrsMerged, totalReviews, mergeTimeHours,
+      topDeveloper, recentPrs,
       prevCommits: prev.commits, prevPrsMerged: prev.prsMerged,
     },
     loading,

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -41,20 +41,20 @@ interface GitHubEvent {
   }
 }
 
-const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const DAY_MS = 24 * 60 * 60 * 1000
 
-function isThisWeek(dateStr: string): boolean {
-  return Date.now() - new Date(dateStr).getTime() < ONE_WEEK_MS
+function isWithinWindow(dateStr: string, windowDays: number): boolean {
+  return Date.now() - new Date(dateStr).getTime() < windowDays * DAY_MS
 }
 
-export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
+export function aggregateEvents(events: GitHubEvent[], windowDays = 7): DeveloperStats[] {
   const map = new Map<string, DeveloperStats>()
   const seen = new Set<string>()
 
   for (const event of events) {
     if (seen.has(event.id)) continue
     seen.add(event.id)
-    if (!isThisWeek(event.created_at)) continue
+    if (!isWithinWindow(event.created_at, windowDays)) continue
 
     const { login, avatar_url } = event.actor
     if (!map.has(login)) {
@@ -66,7 +66,7 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
         prsMerged: 0,
         issuesClosed: 0,
         lastEventAt: null,
-        dailyCommits: Array(7).fill(0),
+        dailyCommits: Array(windowDays).fill(0),
       })
     }
     const dev = map.get(login)!
@@ -78,8 +78,8 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
     if (event.type === 'PushEvent') {
       const count = event.payload.commits?.length ?? 0
       dev.commits += count
-      const daysAgo = Math.floor((Date.now() - new Date(event.created_at).getTime()) / (24 * 60 * 60 * 1000))
-      if (daysAgo < 7) dev.dailyCommits[6 - daysAgo] += count
+      const daysAgo = Math.floor((Date.now() - new Date(event.created_at).getTime()) / DAY_MS)
+      if (daysAgo < windowDays) dev.dailyCommits[windowDays - 1 - daysAgo] += count
     } else if (event.type === 'PullRequestEvent') {
       if (event.payload.action === 'opened') dev.prsOpened++
       if (event.payload.action === 'closed' && event.payload.pull_request?.merged) dev.prsMerged++
@@ -91,14 +91,14 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
   return Array.from(map.values()).sort((a, b) => b.commits - a.commits)
 }
 
-export function extractRecentPrs(events: GitHubEvent[]): RecentPR[] {
+export function extractRecentPrs(events: GitHubEvent[], windowDays = 7): RecentPR[] {
   const seen = new Set<string>()
   const prs: RecentPR[] = []
 
   for (const event of events) {
     if (seen.has(event.id)) continue
     seen.add(event.id)
-    if (!isThisWeek(event.created_at)) continue
+    if (!isWithinWindow(event.created_at, windowDays)) continue
     if (event.type !== 'PullRequestEvent') continue
     if (event.payload.action !== 'closed') continue
     if (!event.payload.pull_request?.merged) continue
@@ -118,7 +118,8 @@ export function extractRecentPrs(events: GitHubEvent[]): RecentPR[] {
 
 export function useTeamStats(
   repos: Array<{ repo_full_name: string }>,
-  githubToken: string | null
+  githubToken: string | null,
+  windowDays = 7,
 ): { stats: TeamStatsData; loading: boolean; error: string | null } {
   const [events, setEvents] = useState<GitHubEvent[]>([])
   const [loading, setLoading] = useState(false)
@@ -154,9 +155,9 @@ export function useTeamStats(
             const events = await res.json() as GitHubEvent[]
             if (events.length === 0) break
             all.push(...events)
-            // Stop early if the oldest event on this page is already outside the 7-day window
+            // Stop early if the oldest event on this page ya está fuera de la ventana
             const oldest = events[events.length - 1]
-            if (Date.now() - new Date(oldest.created_at).getTime() > ONE_WEEK_MS) break
+            if (Date.now() - new Date(oldest.created_at).getTime() > windowDays * DAY_MS) break
           }
           return all
         }
@@ -178,13 +179,13 @@ export function useTeamStats(
 
     void load()
     return () => { alive = false }
-  }, [repoNames, githubToken])
+  }, [repoNames, githubToken, windowDays])
 
-  const developers = useMemo(() => aggregateEvents(events), [events])
+  const developers = useMemo(() => aggregateEvents(events, windowDays), [events, windowDays])
   const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
   const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
   const topDeveloper = developers[0] ?? null
-  const recentPrs = useMemo(() => extractRecentPrs(events), [events])
+  const recentPrs = useMemo(() => extractRecentPrs(events, windowDays), [events, windowDays])
 
   return {
     stats: { developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs },

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect, useMemo } from 'react'
+
+export interface DeveloperStats {
+  login: string
+  avatarUrl: string
+  commits: number
+  prsOpened: number
+  prsMerged: number
+  issuesClosed: number
+  lastEventAt: string | null
+}
+
+export interface TeamStatsData {
+  developers: DeveloperStats[]
+  totalCommits: number
+  totalPrsMerged: number
+  topDeveloper: DeveloperStats | null
+}
+
+interface GitHubEvent {
+  id: string
+  type: string
+  actor: { login: string; avatar_url: string }
+  created_at: string
+  payload: {
+    action?: string
+    commits?: { sha: string; message: string }[]
+    pull_request?: { merged?: boolean }
+  }
+}
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+function isThisWeek(dateStr: string): boolean {
+  return Date.now() - new Date(dateStr).getTime() < ONE_WEEK_MS
+}
+
+export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
+  const map = new Map<string, DeveloperStats>()
+  const seen = new Set<string>()
+
+  for (const event of events) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    if (!isThisWeek(event.created_at)) continue
+
+    const { login, avatar_url } = event.actor
+    if (!map.has(login)) {
+      map.set(login, {
+        login,
+        avatarUrl: avatar_url,
+        commits: 0,
+        prsOpened: 0,
+        prsMerged: 0,
+        issuesClosed: 0,
+        lastEventAt: null,
+      })
+    }
+    const dev = map.get(login)!
+
+    if (!dev.lastEventAt || event.created_at > dev.lastEventAt) {
+      dev.lastEventAt = event.created_at
+    }
+
+    if (event.type === 'PushEvent') {
+      dev.commits += event.payload.commits?.length ?? 0
+    } else if (event.type === 'PullRequestEvent') {
+      if (event.payload.action === 'opened') dev.prsOpened++
+      if (event.payload.action === 'closed' && event.payload.pull_request?.merged) dev.prsMerged++
+    } else if (event.type === 'IssuesEvent' && event.payload.action === 'closed') {
+      dev.issuesClosed++
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.commits - a.commits)
+}
+
+export function useTeamStats(
+  repos: Array<{ repo_full_name: string }>,
+  githubToken: string | null
+): { stats: TeamStatsData; loading: boolean; error: string | null } {
+  const [events, setEvents] = useState<GitHubEvent[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const repoNames = useMemo(
+    () => repos.map(r => r.repo_full_name).join(','),
+    [repos]
+  )
+
+  useEffect(() => {
+    if (!githubToken || !repoNames) return
+    const repoList = repoNames.split(',').filter(Boolean)
+    let alive = true
+    setLoading(true)
+    setError(null)
+
+    const load = async () => {
+      try {
+        const results = await Promise.allSettled(
+          repoList.map(name =>
+            fetch(`https://api.github.com/repos/${name}/events?per_page=100`, {
+              headers: {
+                Authorization: `Bearer ${githubToken}`,
+                Accept: 'application/vnd.github.v3+json',
+              },
+            }).then(res => (res.ok ? (res.json() as Promise<GitHubEvent[]>) : ([] as GitHubEvent[])))
+          )
+        )
+        const all: GitHubEvent[] = []
+        for (const r of results) {
+          if (r.status === 'fulfilled') all.push(...r.value)
+        }
+        if (alive) setEvents(all)
+      } catch (e) {
+        if (alive) setError(e instanceof Error ? e.message : 'Failed to load stats')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => { alive = false }
+  }, [repoNames, githubToken])
+
+  const developers = useMemo(() => aggregateEvents(events), [events])
+  const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
+  const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
+  const topDeveloper = developers[0] ?? null
+
+  return {
+    stats: { developers, totalCommits, totalPrsMerged, topDeveloper },
+    loading,
+    error,
+  }
+}

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -26,6 +26,9 @@ export interface TeamStatsData {
   totalPrsMerged: number
   topDeveloper: DeveloperStats | null
   recentPrs: RecentPR[]
+  /** Totales del período INMEDIATAMENTE anterior (misma duración), para deltas. */
+  prevCommits: number
+  prevPrsMerged: number
 }
 
 interface GitHubEvent {
@@ -116,6 +119,33 @@ export function extractRecentPrs(events: GitHubEvent[], windowDays = 7): RecentP
   return prs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt))
 }
 
+/** Suma commits y PRs mergeados en la ventana [fromDaysAgo, toDaysAgo) (días atrás). */
+export function windowTotals(
+  events: GitHubEvent[],
+  fromDaysAgo: number,
+  toDaysAgo: number,
+): { commits: number; prsMerged: number } {
+  const seen = new Set<string>()
+  let commits = 0
+  let prsMerged = 0
+  for (const event of events) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    const ageDays = (Date.now() - new Date(event.created_at).getTime()) / DAY_MS
+    if (ageDays < fromDaysAgo || ageDays >= toDaysAgo) continue
+    if (event.type === 'PushEvent') {
+      commits += event.payload.commits?.length ?? 0
+    } else if (
+      event.type === 'PullRequestEvent' &&
+      event.payload.action === 'closed' &&
+      event.payload.pull_request?.merged
+    ) {
+      prsMerged++
+    }
+  }
+  return { commits, prsMerged }
+}
+
 export function useTeamStats(
   repos: Array<{ repo_full_name: string }>,
   githubToken: string | null,
@@ -155,9 +185,9 @@ export function useTeamStats(
             const events = await res.json() as GitHubEvent[]
             if (events.length === 0) break
             all.push(...events)
-            // Stop early if the oldest event on this page ya está fuera de la ventana
+            // Traemos 2× la ventana para poder comparar contra el período anterior (deltas).
             const oldest = events[events.length - 1]
-            if (Date.now() - new Date(oldest.created_at).getTime() > windowDays * DAY_MS) break
+            if (Date.now() - new Date(oldest.created_at).getTime() > windowDays * 2 * DAY_MS) break
           }
           return all
         }
@@ -186,9 +216,13 @@ export function useTeamStats(
   const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
   const topDeveloper = developers[0] ?? null
   const recentPrs = useMemo(() => extractRecentPrs(events, windowDays), [events, windowDays])
+  const prev = useMemo(() => windowTotals(events, windowDays, windowDays * 2), [events, windowDays])
 
   return {
-    stats: { developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs },
+    stats: {
+      developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs,
+      prevCommits: prev.commits, prevPrsMerged: prev.prsMerged,
+    },
     loading,
     error,
   }

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -45,6 +45,15 @@ interface GitHubEvent {
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000
+// Ventana máxima que traemos de red (cubre 2× el período más largo, 30d, para deltas).
+// El filtrado a 7/30 días se hace client-side, así togglear Week/Month no re-fetchea.
+const MAX_DAYS = 60
+// Límite de repos en paralelo, para no gatillar el secondary rate limit de GitHub.
+const CONCURRENCY = 5
+// Solo estos tipos de evento cuentan como "contribución" y crean una fila de developer.
+// Sin esto, un WatchEvent/ForkEvent/comentario mete gente que no commiteó al roster.
+const CONTRIB_TYPES = new Set(['PushEvent', 'PullRequestEvent', 'IssuesEvent'])
+const isBot = (login: string): boolean => login.endsWith('[bot]')
 
 function isWithinWindow(dateStr: string, windowDays: number): boolean {
   return Date.now() - new Date(dateStr).getTime() < windowDays * DAY_MS
@@ -58,8 +67,12 @@ export function aggregateEvents(events: GitHubEvent[], windowDays = 7): Develope
     if (seen.has(event.id)) continue
     seen.add(event.id)
     if (!isWithinWindow(event.created_at, windowDays)) continue
+    // Excluir eventos que no son contribución (stars, forks, comentarios) y bots,
+    // para que no ensucien el roster / podium con filas de 0 commits.
+    if (!CONTRIB_TYPES.has(event.type)) continue
 
     const { login, avatar_url } = event.actor
+    if (isBot(login)) continue
     if (!map.has(login)) {
       map.set(login, {
         login,
@@ -133,6 +146,7 @@ export function windowTotals(
     seen.add(event.id)
     const ageDays = (Date.now() - new Date(event.created_at).getTime()) / DAY_MS
     if (ageDays < fromDaysAgo || ageDays >= toDaysAgo) continue
+    if (isBot(event.actor.login)) continue
     if (event.type === 'PushEvent') {
       commits += event.payload.commits?.length ?? 0
     } else if (
@@ -150,29 +164,35 @@ export function useTeamStats(
   repos: Array<{ repo_full_name: string }>,
   githubToken: string | null,
   windowDays = 7,
-): { stats: TeamStatsData; loading: boolean; error: string | null } {
+): { stats: TeamStatsData; loading: boolean; error: string | null; warning: string | null } {
   const [events, setEvents] = useState<GitHubEvent[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [warning, setWarning] = useState<string | null>(null)
 
   const repoNames = useMemo(
     () => repos.map(r => r.repo_full_name).join(','),
     [repos]
   )
 
+  // El fetch NO depende de windowDays: traemos MAX_DAYS de red una sola vez y
+  // filtramos client-side a 7/30. Togglear Week/Month no vuelve a pegarle a GitHub.
   useEffect(() => {
     if (!githubToken || !repoNames) return
     const repoList = repoNames.split(',').filter(Boolean)
     let alive = true
     setLoading(true)
     setError(null)
+    setWarning(null)
 
     const load = async () => {
-      try {
-        const fetchRepoEvents = async (name: string): Promise<GitHubEvent[]> => {
-          const all: GitHubEvent[] = []
-          for (let page = 1; page <= 3; page++) {
-            const res = await fetch(
+      const failed: string[] = []
+      const fetchRepoEvents = async (name: string): Promise<GitHubEvent[]> => {
+        const all: GitHubEvent[] = []
+        for (let page = 1; page <= 3; page++) {
+          let res: Response
+          try {
+            res = await fetch(
               `https://api.github.com/repos/${name}/events?per_page=100&page=${page}`,
               {
                 headers: {
@@ -181,25 +201,43 @@ export function useTeamStats(
                 },
               }
             )
-            if (!res.ok) break
-            const events = await res.json() as GitHubEvent[]
-            if (events.length === 0) break
-            all.push(...events)
-            // Traemos 2× la ventana para poder comparar contra el período anterior (deltas).
-            const oldest = events[events.length - 1]
-            if (Date.now() - new Date(oldest.created_at).getTime() > windowDays * 2 * DAY_MS) break
+          } catch {
+            if (page === 1) failed.push(name)
+            break
           }
-          return all
+          // Un 403 (rate limit) / 404 (sin acceso o repo movido) en la 1ª página
+          // es una falla del repo, no fin de paginación: la registramos.
+          if (!res.ok) {
+            if (page === 1) failed.push(name)
+            break
+          }
+          const events = await res.json() as GitHubEvent[]
+          if (events.length === 0) break
+          all.push(...events)
+          const oldest = events[events.length - 1]
+          if (Date.now() - new Date(oldest.created_at).getTime() > MAX_DAYS * DAY_MS) break
         }
+        return all
+      }
 
-        const results = await Promise.allSettled(
-          repoList.map(name => fetchRepoEvents(name))
-        )
+      try {
         const all: GitHubEvent[] = []
-        for (const r of results) {
-          if (r.status === 'fulfilled') all.push(...r.value)
+        // Pool: procesamos los repos en tandas de CONCURRENCY en vez de todos a la vez.
+        for (let i = 0; i < repoList.length; i += CONCURRENCY) {
+          const batch = repoList.slice(i, i + CONCURRENCY)
+          const results = await Promise.allSettled(batch.map(fetchRepoEvents))
+          for (const r of results) {
+            if (r.status === 'fulfilled') all.push(...r.value)
+          }
         }
-        if (alive) setEvents(all)
+        if (alive) {
+          setEvents(all)
+          setWarning(
+            failed.length
+              ? `No se pudieron cargar ${failed.length} de ${repoList.length} repos (rate limit o sin acceso)`
+              : null
+          )
+        }
       } catch (e) {
         if (alive) setError(e instanceof Error ? e.message : 'Failed to load stats')
       } finally {
@@ -209,7 +247,7 @@ export function useTeamStats(
 
     void load()
     return () => { alive = false }
-  }, [repoNames, githubToken, windowDays])
+  }, [repoNames, githubToken])
 
   const developers = useMemo(() => aggregateEvents(events, windowDays), [events, windowDays])
   const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
@@ -225,5 +263,6 @@ export function useTeamStats(
     },
     loading,
     error,
+    warning,
   }
 }

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -97,15 +97,31 @@ export function useTeamStats(
 
     const load = async () => {
       try {
+        const fetchRepoEvents = async (name: string): Promise<GitHubEvent[]> => {
+          const all: GitHubEvent[] = []
+          for (let page = 1; page <= 3; page++) {
+            const res = await fetch(
+              `https://api.github.com/repos/${name}/events?per_page=100&page=${page}`,
+              {
+                headers: {
+                  Authorization: `Bearer ${githubToken}`,
+                  Accept: 'application/vnd.github.v3+json',
+                },
+              }
+            )
+            if (!res.ok) break
+            const events = await res.json() as GitHubEvent[]
+            if (events.length === 0) break
+            all.push(...events)
+            // Stop early if the oldest event on this page is already outside the 7-day window
+            const oldest = events[events.length - 1]
+            if (Date.now() - new Date(oldest.created_at).getTime() > ONE_WEEK_MS) break
+          }
+          return all
+        }
+
         const results = await Promise.allSettled(
-          repoList.map(name =>
-            fetch(`https://api.github.com/repos/${name}/events?per_page=100`, {
-              headers: {
-                Authorization: `Bearer ${githubToken}`,
-                Accept: 'application/vnd.github.v3+json',
-              },
-            }).then(res => (res.ok ? (res.json() as Promise<GitHubEvent[]>) : ([] as GitHubEvent[])))
-          )
+          repoList.map(name => fetchRepoEvents(name))
         )
         const all: GitHubEvent[] = []
         for (const r of results) {

--- a/src/hooks/useTeamStats.ts
+++ b/src/hooks/useTeamStats.ts
@@ -8,6 +8,16 @@ export interface DeveloperStats {
   prsMerged: number
   issuesClosed: number
   lastEventAt: string | null
+  dailyCommits: number[]   // 7 elements, index 0 = 6 days ago, index 6 = today
+}
+
+export interface RecentPR {
+  id: string
+  login: string
+  avatarUrl: string
+  title: string
+  repo: string      // full repo name e.g. "owner/repo"
+  mergedAt: string  // ISO string
 }
 
 export interface TeamStatsData {
@@ -15,17 +25,19 @@ export interface TeamStatsData {
   totalCommits: number
   totalPrsMerged: number
   topDeveloper: DeveloperStats | null
+  recentPrs: RecentPR[]
 }
 
 interface GitHubEvent {
   id: string
   type: string
   actor: { login: string; avatar_url: string }
+  repo: { name: string }   // full repo name e.g. "owner/repo"
   created_at: string
   payload: {
     action?: string
     commits?: { sha: string; message: string }[]
-    pull_request?: { merged?: boolean }
+    pull_request?: { merged?: boolean; title?: string }
   }
 }
 
@@ -54,6 +66,7 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
         prsMerged: 0,
         issuesClosed: 0,
         lastEventAt: null,
+        dailyCommits: Array(7).fill(0),
       })
     }
     const dev = map.get(login)!
@@ -63,7 +76,10 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
     }
 
     if (event.type === 'PushEvent') {
-      dev.commits += event.payload.commits?.length ?? 0
+      const count = event.payload.commits?.length ?? 0
+      dev.commits += count
+      const daysAgo = Math.floor((Date.now() - new Date(event.created_at).getTime()) / (24 * 60 * 60 * 1000))
+      if (daysAgo < 7) dev.dailyCommits[6 - daysAgo] += count
     } else if (event.type === 'PullRequestEvent') {
       if (event.payload.action === 'opened') dev.prsOpened++
       if (event.payload.action === 'closed' && event.payload.pull_request?.merged) dev.prsMerged++
@@ -73,6 +89,31 @@ export function aggregateEvents(events: GitHubEvent[]): DeveloperStats[] {
   }
 
   return Array.from(map.values()).sort((a, b) => b.commits - a.commits)
+}
+
+export function extractRecentPrs(events: GitHubEvent[]): RecentPR[] {
+  const seen = new Set<string>()
+  const prs: RecentPR[] = []
+
+  for (const event of events) {
+    if (seen.has(event.id)) continue
+    seen.add(event.id)
+    if (!isThisWeek(event.created_at)) continue
+    if (event.type !== 'PullRequestEvent') continue
+    if (event.payload.action !== 'closed') continue
+    if (!event.payload.pull_request?.merged) continue
+
+    prs.push({
+      id: event.id,
+      login: event.actor.login,
+      avatarUrl: event.actor.avatar_url,
+      title: event.payload.pull_request.title ?? '(no title)',
+      repo: event.repo?.name ?? '',
+      mergedAt: event.created_at,
+    })
+  }
+
+  return prs.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt))
 }
 
 export function useTeamStats(
@@ -143,9 +184,10 @@ export function useTeamStats(
   const totalCommits = developers.reduce((s, d) => s + d.commits, 0)
   const totalPrsMerged = developers.reduce((s, d) => s + d.prsMerged, 0)
   const topDeveloper = developers[0] ?? null
+  const recentPrs = useMemo(() => extractRecentPrs(events), [events])
 
   return {
-    stats: { developers, totalCommits, totalPrsMerged, topDeveloper },
+    stats: { developers, totalCommits, totalPrsMerged, topDeveloper, recentPrs },
     loading,
     error,
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9329,3 +9329,128 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .tour-progress i.on { background: #3d79ff; width: 14px; border-radius: 3px; }
 .tour-help-btn { background: none; border: 1px solid #2b2b32; color: #9a9aa3; border-radius: 8px; width: 26px; height: 26px; cursor: pointer; font-size: 14px; }
 .tour-help-btn:hover { color: #ededed; border-color: #3a3a42; }
+
+/* ── Team Stats ──────────────────────────────────────────── */
+.ts-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 14px;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.ts-overview-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.ts-card {
+  background: #ffffff08;
+  border: 1px solid #ffffff12;
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ts-card-label {
+  font-size: 10px;
+  color: #ffffff55;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ts-card-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: #fff;
+  line-height: 1;
+}
+
+.ts-card-sub {
+  font-size: 11px;
+  color: #ffffff66;
+}
+
+.ts-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #ffffff55;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 6px;
+}
+
+.ts-table-wrap {
+  overflow-x: auto;
+}
+
+.ts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.ts-table th {
+  text-align: left;
+  font-size: 10px;
+  font-weight: 500;
+  color: #ffffff44;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 8px 8px;
+  white-space: nowrap;
+}
+
+.ts-table th:first-child { padding-left: 0; }
+
+.ts-table td {
+  padding: 6px 8px;
+  color: #ffffffcc;
+  border-top: 1px solid #ffffff08;
+  vertical-align: middle;
+}
+
+.ts-table td:first-child { padding-left: 0; }
+
+.ts-table tr:hover td { background: #ffffff05; }
+
+.ts-dev-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ts-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ts-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ts-status-dot.online  { background: #22c55e; }
+.ts-status-dot.offline { background: #ffffff22; }
+
+.ts-num {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.ts-muted { color: #ffffff44; }
+
+.ts-empty {
+  padding: 40px 0;
+  text-align: center;
+  color: #ffffff44;
+  font-size: 12px;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9398,6 +9398,36 @@ body.platform-mac .tabbar { padding-right: 116px; }
   margin-bottom: 8px;
 }
 
+.ts-cards-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.ts-cards-header .ts-section-title { margin-bottom: 0; }
+
+.ts-toggle {
+  display: inline-flex;
+  background: #ffffff08;
+  border: 1px solid #ffffff12;
+  border-radius: 8px;
+  padding: 2px;
+  gap: 2px;
+}
+.ts-toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #ffffff55;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 6px;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.ts-toggle-btn:hover { color: #ffffff88; }
+.ts-toggle-btn.active { background: #ffffff14; color: #fff; }
+
 .ts-table-wrap {
   overflow-x: auto;
   border: 1px solid #ffffff10;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9454,3 +9454,98 @@ body.platform-mac .tabbar { padding-right: 116px; }
   color: #ffffff44;
   font-size: 12px;
 }
+
+/* ── Team Stats — sparklines ────────────────────────── */
+
+.ts-sparkline {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 18px;
+  width: 52px;
+}
+
+.ts-spark-bar {
+  flex: 1;
+  background: #0066FF;
+  border-radius: 1px;
+  min-height: 2px;
+}
+
+/* ── Team Stats — sortable column headers ───────────── */
+
+.ts-th-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  opacity: 1;
+}
+
+.ts-th-btn:hover { color: #ffffff88; }
+
+.ts-sort-icon {
+  font-size: 9px;
+  opacity: 0.25;
+  line-height: 1;
+}
+
+.ts-sort-icon.active {
+  opacity: 0.8;
+  color: #0066FF;
+}
+
+/* ── Team Stats — PR feed ───────────────────────────── */
+
+.ts-pr-feed {
+  display: flex;
+  flex-direction: column;
+}
+
+.ts-pr-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-top: 1px solid #ffffff08;
+}
+
+.ts-pr-item:first-child { border-top: none; }
+
+.ts-pr-meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ts-pr-title {
+  font-size: 12px;
+  color: #ffffffcc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ts-pr-sub {
+  font-size: 10px;
+  color: #ffffff44;
+}
+
+.ts-pr-merged-badge {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: #22c55e18;
+  border: 1px solid #22c55e30;
+  color: #22c55e;
+  white-space: nowrap;
+  flex-shrink: 0;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9644,3 +9644,128 @@ body.platform-mac .tabbar { padding-right: 116px; }
   margin: 0 auto 10px;
   opacity: 0.35;
 }
+
+/* ── Team Stats — delta badges (▲▼ vs período anterior) ─ */
+.ts-delta {
+  font-size: 10px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  margin-left: 3px;
+  white-space: nowrap;
+}
+.ts-delta.up   { color: #3fb950; }
+.ts-delta.down { color: #f85149; }
+.ts-delta.flat { color: #ffffff44; }
+
+/* ── Team Stats — team activity bar chart ───────────── */
+.ts-chart { position: relative; }
+.ts-chart-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 120px;
+  overflow: visible;
+}
+.ts-bar-col {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  position: relative;
+}
+.ts-bar {
+  width: 100%;
+  min-height: 2px;
+  background: var(--ts-accent);
+  border-radius: 3px 3px 0 0;
+  opacity: 0.85;
+  transition: opacity 0.12s ease, filter 0.12s ease;
+}
+.ts-bar-col:hover .ts-bar,
+.ts-bar-col.hover .ts-bar { opacity: 1; filter: brightness(1.18); }
+.ts-bar-tip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, calc(-100% - 4px));
+  background: #0b0f17;
+  border: 1px solid #ffffff20;
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  color: #fff;
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  z-index: 5;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+.ts-bar-tip span { color: #ffffff66; font-size: 10px; }
+.ts-chart-foot {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 10px;
+  color: #ffffff40;
+}
+.ts-chart-total { color: #ffffff70; font-weight: 600; }
+
+/* ── Team Stats — top performers podium ─────────────── */
+.ts-podium {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+@media (max-width: 520px) { .ts-podium { grid-template-columns: 1fr; } }
+.ts-podium-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 16px 12px 12px;
+  background: #ffffff06;
+  border: 1px solid #ffffff12;
+  border-top: 2px solid #ffffff20;
+  border-radius: 10px;
+  text-align: center;
+}
+.ts-podium-0 { border-top-color: #f5c518; background: #f5c51810; }
+.ts-podium-1 { border-top-color: #c0c6d0; background: #c0c6d010; }
+.ts-podium-2 { border-top-color: #cd7f32; background: #cd7f3210; }
+.ts-medal { position: absolute; top: 8px; left: 10px; font-size: 16px; line-height: 1; }
+.ts-podium-av { width: 40px; height: 40px; border-radius: 50%; }
+.ts-podium-name {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 600; color: #fff;
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ts-podium-commits {
+  font-size: 20px; font-weight: 700; color: #fff;
+  font-variant-numeric: tabular-nums; line-height: 1.1;
+}
+.ts-podium-sub { font-size: 11px; color: #ffffff55; }
+
+/* ── Team Stats — activity heatmap (devs × days) ────── */
+.ts-heatmap { display: flex; flex-direction: column; gap: 4px; }
+.ts-heat-row {
+  display: grid;
+  grid-template-columns: 116px 1fr;
+  align-items: center;
+  gap: 10px;
+}
+.ts-heat-name {
+  font-size: 11px; color: #ffffffaa;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ts-heat-cells { display: grid; gap: 3px; }
+.ts-heat-cell {
+  aspect-ratio: 1;
+  min-height: 12px;
+  border-radius: 2px;
+  background: #ffffff0a;
+}
+.ts-heat-more { font-size: 11px; color: #ffffff44; margin-top: 2px; padding-left: 126px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9613,3 +9613,33 @@ body.platform-mac .tabbar { padding-right: 116px; }
   white-space: nowrap;
   flex-shrink: 0;
 }
+
+/* ── Team Stats — skeleton ──────────────────────────── */
+@keyframes ts-skeleton-shimmer {
+  0%   { background-position: -180px 0; }
+  100% { background-position: 180px 0; }
+}
+.ts-skeleton {
+  background: #ffffff0c;
+  border-radius: 6px;
+  background-image: linear-gradient(90deg, #ffffff00 0, #ffffff14 50%, #ffffff00 100%);
+  background-size: 180px 100%;
+  background-repeat: no-repeat;
+  animation: ts-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+.ts-skel-card { height: 78px; border-radius: 10px; }
+.ts-skel-row {
+  height: 40px;
+  border-radius: 8px;
+  margin-top: 6px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ts-skeleton { animation: none; }
+}
+
+/* ── Team Stats — empty state icon ──────────────────── */
+.ts-empty-icon {
+  display: block;
+  margin: 0 auto 10px;
+  opacity: 0.35;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9424,6 +9424,12 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 8px;
 }
 
+.ts-dev-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .ts-avatar {
   width: 22px;
   height: 22px;
@@ -9461,8 +9467,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: flex;
   align-items: flex-end;
   gap: 2px;
-  height: 18px;
-  width: 52px;
+  height: 24px;
+  width: 60px;
 }
 
 .ts-spark-bar {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9348,38 +9348,27 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .ts-card {
-  background: #ffffff08;
-  border: 1px solid #ffffff12;
-  border-top: 2px solid #ffffff20;
-  border-radius: 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
   padding: 13px 15px;
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
 
-.ts-card--green  { background: #22c55e10; border-color: #22c55e28; border-top-color: #22c55e; }
-.ts-card--blue   { background: #3b82f610; border-color: #3b82f628; border-top-color: #3b82f6; }
-.ts-card--purple { background: #a855f710; border-color: #a855f728; border-top-color: #a855f7; }
-.ts-card--amber  { background: #f59e0b10; border-color: #f59e0b28; border-top-color: #f59e0b; }
-
 .ts-card-label {
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: #ffffff44;
+  letter-spacing: 0.8px;
+  color: var(--text-muted);
 }
-
-.ts-card--green  .ts-card-label { color: #22c55e; }
-.ts-card--blue   .ts-card-label { color: #3b82f6; }
-.ts-card--purple .ts-card-label { color: #a855f7; }
-.ts-card--amber  .ts-card-label { color: #f59e0b; }
 
 .ts-card-value {
   font-size: 26px;
   font-weight: 700;
-  color: #fff;
+  color: var(--text-primary);
   line-height: 1;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.02em;
@@ -9387,15 +9376,15 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .ts-card-sub {
   font-size: 11px;
-  color: #ffffff55;
+  color: var(--text-secondary);
 }
 
 .ts-section-title {
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
-  color: #ffffff33;
+  color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.8px;
   margin-bottom: 8px;
 }
 
@@ -9409,8 +9398,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .ts-toggle {
   display: inline-flex;
-  background: #ffffff08;
-  border: 1px solid #ffffff12;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 2px;
   gap: 2px;
@@ -9419,21 +9408,21 @@ body.platform-mac .tabbar { padding-right: 116px; }
   background: none;
   border: none;
   cursor: pointer;
-  color: #ffffff55;
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 600;
   padding: 4px 12px;
   border-radius: 6px;
   transition: background 0.12s ease, color 0.12s ease;
 }
-.ts-toggle-btn:hover { color: #ffffff88; }
-.ts-toggle-btn.active { background: #ffffff14; color: #fff; }
+.ts-toggle-btn:hover { color: var(--text-primary); }
+.ts-toggle-btn.active { background: var(--bg-elevated); color: var(--text-primary); }
 
 .ts-table-wrap {
   overflow-x: auto;
-  border: 1px solid #ffffff10;
-  border-radius: 10px;
-  background: #ffffff03;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
 }
 
 .ts-table {
@@ -9446,24 +9435,24 @@ body.platform-mac .tabbar { padding-right: 116px; }
   text-align: left;
   font-size: 10px;
   font-weight: 600;
-  color: #ffffff33;
+  color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.8px;
   padding: 10px 12px;
   white-space: nowrap;
-  border-bottom: 1px solid #ffffff0a;
+  border-bottom: 1px solid var(--border);
 }
 
 .ts-table td {
   padding: 9px 12px;
-  color: #ffffffcc;
-  border-top: 1px solid #ffffff06;
+  color: var(--text-primary);
+  border-top: 1px solid var(--border);
   vertical-align: middle;
 }
 
 .ts-table tr:first-child td { border-top: none; }
-.ts-table tr:hover td { background: #ffffff04; }
-.ts-top-row td { background: #f59e0b06; }
+.ts-table tr:hover td { background: var(--bg-elevated); }
+.ts-top-row td { background: var(--bg-elevated); }
 
 .ts-dev-cell {
   display: flex;
@@ -9480,23 +9469,21 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .ts-dev-name {
   font-size: 12px;
   font-weight: 500;
-  color: #e2e2e2;
+  color: var(--text-primary);
   white-space: nowrap;
 }
 
-.ts-top-row .ts-dev-name { color: #fff; font-weight: 600; }
+.ts-top-row .ts-dev-name { font-weight: 600; }
 
 .ts-rank {
   font-size: 10px;
   font-weight: 600;
-  color: #ffffff25;
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   width: 14px;
   text-align: right;
   flex-shrink: 0;
 }
-
-.ts-top-row .ts-rank { color: #f59e0b; }
 
 .ts-avatar {
   width: 24px;
@@ -9506,8 +9493,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 @keyframes ts-online-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 #22c55e55; }
-  50%       { box-shadow: 0 0 0 4px #22c55e00; }
+  0%, 100% { box-shadow: 0 0 0 0 #3fb95055; }
+  50%       { box-shadow: 0 0 0 4px #3fb95000; }
 }
 
 .ts-status-dot {
@@ -9517,20 +9504,20 @@ body.platform-mac .tabbar { padding-right: 116px; }
   flex-shrink: 0;
 }
 
-.ts-status-dot.online  { background: #22c55e; animation: ts-online-pulse 2.5s ease-in-out infinite; }
-.ts-status-dot.offline { background: #ffffff18; }
+.ts-status-dot.online  { background: #3fb950; animation: ts-online-pulse 2.5s ease-in-out infinite; }
+.ts-status-dot.offline { background: #3a3a3a; }
 
 .ts-num {
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
 
-.ts-muted { color: #ffffff30; }
+.ts-muted { color: var(--text-muted); }
 
 .ts-empty {
   padding: 40px 0;
   text-align: center;
-  color: #ffffff33;
+  color: var(--text-muted);
   font-size: 12px;
 }
 
@@ -9553,17 +9540,17 @@ body.platform-mac .tabbar { padding-right: 116px; }
   white-space: nowrap;
 }
 
-.ts-th-btn:hover { color: #ffffff66; }
+.ts-th-btn:hover { color: var(--text-secondary); }
 
 .ts-sort-icon {
   font-size: 9px;
-  opacity: 0.25;
+  opacity: 0.35;
   line-height: 1;
 }
 
 .ts-sort-icon.active {
-  opacity: 0.9;
-  color: #3b82f6;
+  opacity: 1;
+  color: var(--text-secondary);
 }
 
 /* ── Team Stats — PR feed ───────────────────────────── */
@@ -9655,7 +9642,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 .ts-delta.up   { color: #3fb950; }
 .ts-delta.down { color: #f85149; }
-.ts-delta.flat { color: #ffffff44; }
+.ts-delta.flat { color: var(--text-muted); }
 
 /* ── Team Stats — team activity bar chart ───────────── */
 .ts-chart { position: relative; }
@@ -9688,12 +9675,12 @@ body.platform-mac .tabbar { padding-right: 116px; }
   top: 0;
   left: 50%;
   transform: translate(-50%, calc(-100% - 4px));
-  background: #0b0f17;
-  border: 1px solid #ffffff20;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 4px 8px;
   font-size: 11px;
-  color: #fff;
+  color: var(--text-primary);
   white-space: nowrap;
   display: flex;
   flex-direction: column;
@@ -9701,53 +9688,80 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 1px;
   z-index: 5;
   pointer-events: none;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
 }
-.ts-bar-tip span { color: #ffffff66; font-size: 10px; }
+.ts-bar-tip span { color: var(--text-secondary); font-size: 10px; }
 .ts-chart-foot {
   display: flex;
   justify-content: space-between;
   margin-top: 6px;
   font-size: 10px;
-  color: #ffffff40;
+  color: var(--text-muted);
 }
-.ts-chart-total { color: #ffffff70; font-weight: 600; }
+.ts-chart-total { color: var(--text-secondary); font-weight: 600; }
 
-/* ── Team Stats — top performers podium ─────────────── */
-.ts-podium {
+/* ── Team Stats — top performers (ranked list) ──────── */
+.ts-podium { display: flex; flex-direction: column; gap: 4px; }
+.ts-podium-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
-}
-@media (max-width: 520px) { .ts-podium { grid-template-columns: 1fr; } }
-.ts-podium-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
-  gap: 4px;
-  padding: 16px 12px 12px;
-  background: #ffffff06;
-  border: 1px solid #ffffff12;
-  border-top: 2px solid #ffffff20;
-  border-radius: 10px;
+  gap: 12px;
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.ts-podium-rank {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  width: 14px;
   text-align: center;
 }
-.ts-podium-0 { border-top-color: #f5c518; background: #f5c51810; }
-.ts-podium-1 { border-top-color: #c0c6d0; background: #c0c6d010; }
-.ts-podium-2 { border-top-color: #cd7f32; background: #cd7f3210; }
-.ts-medal { position: absolute; top: 8px; left: 10px; font-size: 16px; line-height: 1; }
-.ts-podium-av { width: 40px; height: 40px; border-radius: 50%; }
+.ts-podium-row:first-child .ts-podium-rank { color: var(--text-primary); }
+.ts-podium-av-wrap { position: relative; flex-shrink: 0; display: block; }
+.ts-podium-av { width: 30px; height: 30px; border-radius: 50%; display: block; }
+.ts-podium-dot {
+  position: absolute;
+  bottom: -1px;
+  right: -1px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-app);
+}
+.ts-podium-dot.online  { background: #3fb950; }
+.ts-podium-dot.offline { background: #3a3a3a; }
+.ts-podium-info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .ts-podium-name {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 13px; font-weight: 600; color: #fff;
-  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+.ts-podium-sub { font-size: 11px; color: var(--text-muted); }
 .ts-podium-commits {
-  font-size: 20px; font-weight: 700; color: #fff;
-  font-variant-numeric: tabular-nums; line-height: 1.1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
-.ts-podium-sub { font-size: 11px; color: #ffffff55; }
+.ts-podium-unit {
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  margin-top: 2px;
+}
 
 /* ── Team Stats — activity heatmap (devs × days) ────── */
 .ts-heatmap { display: flex; flex-direction: column; gap: 4px; }
@@ -9758,7 +9772,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   gap: 10px;
 }
 .ts-heat-name {
-  font-size: 11px; color: #ffffffaa;
+  font-size: 11px; color: var(--text-secondary);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .ts-heat-cells { display: grid; gap: 3px; }
@@ -9766,6 +9780,6 @@ body.platform-mac .tabbar { padding-right: 116px; }
   aspect-ratio: 1;
   min-height: 12px;
   border-radius: 2px;
-  background: #ffffff0a;
+  background: var(--bg-elevated);
 }
-.ts-heat-more { font-size: 11px; color: #ffffff44; margin-top: 2px; padding-left: 126px; }
+.ts-heat-more { font-size: 11px; color: var(--text-muted); margin-top: 2px; padding-left: 126px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9332,6 +9332,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 /* ── Team Stats ──────────────────────────────────────────── */
 .ts-container {
+  --ts-accent: #0066ff;
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9334,8 +9334,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .ts-container {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 14px;
+  gap: 20px;
+  padding: 18px;
   height: 100%;
   overflow-y: auto;
 }
@@ -9343,49 +9343,66 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .ts-overview-row {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
+  gap: 10px;
 }
 
 .ts-card {
   background: #ffffff08;
   border: 1px solid #ffffff12;
-  border-radius: 8px;
-  padding: 12px 14px;
+  border-top: 2px solid #ffffff20;
+  border-radius: 10px;
+  padding: 13px 15px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
 }
+
+.ts-card--green  { background: #22c55e10; border-color: #22c55e28; border-top-color: #22c55e; }
+.ts-card--blue   { background: #3b82f610; border-color: #3b82f628; border-top-color: #3b82f6; }
+.ts-card--purple { background: #a855f710; border-color: #a855f728; border-top-color: #a855f7; }
+.ts-card--amber  { background: #f59e0b10; border-color: #f59e0b28; border-top-color: #f59e0b; }
 
 .ts-card-label {
   font-size: 10px;
-  color: #ffffff55;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.07em;
+  color: #ffffff44;
 }
 
+.ts-card--green  .ts-card-label { color: #22c55e; }
+.ts-card--blue   .ts-card-label { color: #3b82f6; }
+.ts-card--purple .ts-card-label { color: #a855f7; }
+.ts-card--amber  .ts-card-label { color: #f59e0b; }
+
 .ts-card-value {
-  font-size: 22px;
-  font-weight: 600;
+  font-size: 26px;
+  font-weight: 700;
   color: #fff;
   line-height: 1;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
 }
 
 .ts-card-sub {
   font-size: 11px;
-  color: #ffffff66;
+  color: #ffffff55;
 }
 
 .ts-section-title {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
-  color: #ffffff55;
+  color: #ffffff33;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 6px;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
 }
 
 .ts-table-wrap {
   overflow-x: auto;
+  border: 1px solid #ffffff10;
+  border-radius: 10px;
+  background: #ffffff03;
 }
 
 .ts-table {
@@ -9397,26 +9414,25 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .ts-table th {
   text-align: left;
   font-size: 10px;
-  font-weight: 500;
-  color: #ffffff44;
+  font-weight: 600;
+  color: #ffffff33;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0 8px 8px;
+  letter-spacing: 0.06em;
+  padding: 10px 12px;
   white-space: nowrap;
+  border-bottom: 1px solid #ffffff0a;
 }
 
-.ts-table th:first-child { padding-left: 0; }
-
 .ts-table td {
-  padding: 6px 8px;
+  padding: 9px 12px;
   color: #ffffffcc;
-  border-top: 1px solid #ffffff08;
+  border-top: 1px solid #ffffff06;
   vertical-align: middle;
 }
 
-.ts-table td:first-child { padding-left: 0; }
-
-.ts-table tr:hover td { background: #ffffff05; }
+.ts-table tr:first-child td { border-top: none; }
+.ts-table tr:hover td { background: #ffffff04; }
+.ts-top-row td { background: #f59e0b06; }
 
 .ts-dev-cell {
   display: flex;
@@ -9427,14 +9443,40 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .ts-dev-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
 }
 
+.ts-dev-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: #e2e2e2;
+  white-space: nowrap;
+}
+
+.ts-top-row .ts-dev-name { color: #fff; font-weight: 600; }
+
+.ts-rank {
+  font-size: 10px;
+  font-weight: 600;
+  color: #ffffff25;
+  font-variant-numeric: tabular-nums;
+  width: 14px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.ts-top-row .ts-rank { color: #f59e0b; }
+
 .ts-avatar {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+@keyframes ts-online-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 #22c55e55; }
+  50%       { box-shadow: 0 0 0 4px #22c55e00; }
 }
 
 .ts-status-dot {
@@ -9444,39 +9486,26 @@ body.platform-mac .tabbar { padding-right: 116px; }
   flex-shrink: 0;
 }
 
-.ts-status-dot.online  { background: #22c55e; }
-.ts-status-dot.offline { background: #ffffff22; }
+.ts-status-dot.online  { background: #22c55e; animation: ts-online-pulse 2.5s ease-in-out infinite; }
+.ts-status-dot.offline { background: #ffffff18; }
 
 .ts-num {
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
 
-.ts-muted { color: #ffffff44; }
+.ts-muted { color: #ffffff30; }
 
 .ts-empty {
   padding: 40px 0;
   text-align: center;
-  color: #ffffff44;
+  color: #ffffff33;
   font-size: 12px;
 }
 
-/* ── Team Stats — sparklines ────────────────────────── */
+/* ── Team Stats — sparklines (SVG area) ─────────────── */
 
-.ts-sparkline {
-  display: flex;
-  align-items: flex-end;
-  gap: 2px;
-  height: 24px;
-  width: 60px;
-}
-
-.ts-spark-bar {
-  flex: 1;
-  background: #0066FF;
-  border-radius: 1px;
-  min-height: 2px;
-}
+.ts-spark { display: block; }
 
 /* ── Team Stats — sortable column headers ───────────── */
 
@@ -9491,10 +9520,9 @@ body.platform-mac .tabbar { padding-right: 116px; }
   align-items: center;
   gap: 4px;
   white-space: nowrap;
-  opacity: 1;
 }
 
-.ts-th-btn:hover { color: #ffffff88; }
+.ts-th-btn:hover { color: #ffffff66; }
 
 .ts-sort-icon {
   font-size: 9px;
@@ -9503,8 +9531,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .ts-sort-icon.active {
-  opacity: 0.8;
-  color: #0066FF;
+  opacity: 0.9;
+  color: #3b82f6;
 }
 
 /* ── Team Stats — PR feed ───────────────────────────── */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9343,8 +9343,11 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 .ts-overview-row {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
+}
+@media (max-width: 520px) {
+  .ts-overview-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 .ts-card {
@@ -9664,30 +9667,60 @@ body.platform-mac .tabbar { padding-right: 116px; }
 
 /* ── Team Stats — team activity bar chart ───────────── */
 .ts-chart { position: relative; }
+.ts-chart-plot {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+}
+.ts-chart-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 120px;
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  padding-bottom: 1px;
+}
+.ts-chart-grid {
+  position: relative;
+  height: 120px;
+}
+.ts-grid-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 0;
+  border-top: 1px dashed var(--border);
+  pointer-events: none;
+}
 .ts-chart-bars {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: flex-end;
-  gap: 2px;
-  height: 120px;
-  overflow: visible;
+  gap: 3px;
 }
 .ts-bar-col {
   flex: 1;
   height: 100%;
   display: flex;
   align-items: flex-end;
+  justify-content: center;
   position: relative;
 }
 .ts-bar {
   width: 100%;
+  max-width: 34px;
   min-height: 2px;
-  background: var(--ts-accent);
-  border-radius: 3px 3px 0 0;
-  opacity: 0.85;
-  transition: opacity 0.12s ease, filter 0.12s ease;
+  background: color-mix(in srgb, var(--ts-accent) 55%, transparent);
+  border-radius: 4px 4px 0 0;
+  transition: filter 0.12s ease, background 0.12s ease;
 }
+.ts-bar.today { background: var(--ts-accent); }
 .ts-bar-col:hover .ts-bar,
-.ts-bar-col.hover .ts-bar { opacity: 1; filter: brightness(1.18); }
+.ts-bar-col.hover .ts-bar { filter: brightness(1.2); background: var(--ts-accent); }
 .ts-bar-tip {
   position: absolute;
   top: 0;
@@ -9717,69 +9750,6 @@ body.platform-mac .tabbar { padding-right: 116px; }
   color: var(--text-muted);
 }
 .ts-chart-total { color: var(--text-secondary); font-weight: 600; }
-
-/* ── Team Stats — top performers (ranked list) ──────── */
-.ts-podium { display: flex; flex-direction: column; gap: 4px; }
-.ts-podium-row {
-  display: grid;
-  grid-template-columns: auto auto 1fr auto;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 12px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-.ts-podium-rank {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-  width: 14px;
-  text-align: center;
-}
-.ts-podium-row:first-child .ts-podium-rank { color: var(--text-primary); }
-.ts-podium-av-wrap { position: relative; flex-shrink: 0; display: block; }
-.ts-podium-av { width: 30px; height: 30px; border-radius: 50%; display: block; }
-.ts-podium-dot {
-  position: absolute;
-  bottom: -1px;
-  right: -1px;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  border: 2px solid var(--bg-app);
-}
-.ts-podium-dot.online  { background: #3fb950; }
-.ts-podium-dot.offline { background: #3a3a3a; }
-.ts-podium-info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.ts-podium-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.ts-podium-sub { font-size: 11px; color: var(--text-muted); }
-.ts-podium-commits {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-.ts-podium-unit {
-  font-size: 9px;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.6px;
-  margin-top: 2px;
-}
 
 /* ── Team Stats — activity heatmap (devs × days) ────── */
 .ts-heatmap { display: flex; flex-direction: column; gap: 4px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9464,6 +9464,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: flex;
   flex-direction: column;
   gap: 5px;
+  min-width: 0;
 }
 
 .ts-dev-name {
@@ -9471,6 +9472,9 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-weight: 500;
   color: var(--text-primary);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
 }
 
 .ts-top-row .ts-dev-name { font-weight: 600; }
@@ -9631,6 +9635,20 @@ body.platform-mac .tabbar { padding-right: 116px; }
   margin: 0 auto 10px;
   opacity: 0.35;
 }
+
+/* ── Team Stats — partial-load warning ──────────────── */
+.ts-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: #d9a441;
+  font-size: 12px;
+}
+.ts-warning svg { flex-shrink: 0; }
 
 /* ── Team Stats — delta badges (▲▼ vs período anterior) ─ */
 .ts-delta {


### PR DESCRIPTION
## Resumen

Agrega el tab **Stats** a `TeamsWorkspace`: dashboard de actividad del equipo (semana/mes) visible solo para líderes — commits, PRs, issues, quién está online, gráfico de actividad, top performers y heatmap. Usa datos que ya fluyen por la app (GitHub Events API + Supabase Presence). **Sin migraciones de DB, sin dependencias nuevas.**

- **UI** (`TeamStats.tsx` + clases `.ts-*` en `global.css`): overview cards, tabla de devs ordenable, gráfico de barras de actividad con hover, delta badges ▲▼ vs período anterior, top-3 como lista ranked, heatmap devs×días, skeleton de carga y empty states. Estilado con los tokens CSS de Nest (monocromo).
- **Datos** (`useTeamStats.ts`): fetch de GitHub Events con pool de concurrencia (5), un solo fetch de 60 días + filtro client-side al togglear Week/Month (no re-fetchea), exclusión de bots `[bot]` y de eventos no-contribución (stars/forks/comentarios) del roster, y warning "N de M repos" si algún repo falla en vez de subreportar callado.
- **Presencia** (`useTeamPresence.ts`): la presencia ahora lleva el `github_login` real del perfil — antes se adivinaba por el prefijo del email y daba falsos offline.
- **Fixes**: crash de hooks (`useMemo` tras early returns), memoización para que los cambios de presencia no re-rendericen todo el árbol, truncado de nombres largos, clamp del tooltip.

## Verificación

- [x] `npm test` — 209/209 verdes en 31 archivos (28 tests de analytics: agregación, ventana Week/Month, exclusión de bots/no-contribución, estados loading/error/sort, matching de online)
- [x] `npx tsc --noEmit` — limpio
- [x] Rebase sobre `main` (v1.3.2) sin conflictos — CI nuevo (typecheck + tests + build) corriendo en este PR
- [x] Smoke test e2e de Playwright del tab Stats en `TeamsWorkspace`
- [ ] Pendiente de validación: smoke en macOS/Linux (desarrollé en Windows)
- [x] App real con datos de volumen — validado en Windows contra Supabase local (Docker) con un team de 4 repos: `facebook/react`, `microsoft/vscode`, `vercel/next.js` y este repo. Carga datos reales de la GitHub Events API (roster grande de contributors), skeleton → datos OK, toggle Week/Month OK, empty state en team sin repos OK, y el gating de líder funcionando en la app corriendo.

## Notas

- **Limitación conocida:** `/repos/:owner/:repo/events` topa en ~300 eventos / ~90 días por repo — en orgs muy activos el período "Month" puede quedar sub-contado.
- El tab se gatea por rol (`isTeamLeader`) en la UI; el detalle del follow-up de permisos va por privado.
- El diff supera el target de ~200-400 líneas (es anterior a la regla de PRs chicos) — si preferís lo partimos como hicimos con el #10.

