### PR TITLE
fix(accounts): guard contra delete con nombre vacío que borraba todas las cuentas del aiType

### DIFF
--- a/electron/__tests__/account-store.test.ts
+++ b/electron/__tests__/account-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, existsSync } from 'fs'
+import { join } from 'path'
+import { makeTmpDir, cleanupTmp } from './setup'
+
+describe('AccountStore', () => {
+  let home: string
+  let storeModule: typeof import('../account-store')
+
+  beforeEach(async () => {
+    home = makeTmpDir('raven-accounts-')
+    process.env.RAVEN_HOME = home
+    vi.resetModules()
+    storeModule = await import('../account-store')
+  })
+
+  afterEach(() => {
+    delete process.env.RAVEN_HOME
+    cleanupTmp(home)
+  })
+
+  it('save + list + delete round-trip', () => {
+    const store = new storeModule.AccountStore()
+    store.save('terminal', 'work')
+    store.save('terminal', 'personal')
+    expect(store.list('terminal').sort()).toEqual(['personal', 'work'])
+    store.delete('terminal', 'work')
+    expect(store.list('terminal')).toEqual(['personal'])
+  })
+
+  it('rejects account names with path traversal', () => {
+    const store = new storeModule.AccountStore()
+    expect(() => store.getDir('terminal', '../otro')).toThrow(/Invalid account name/)
+    expect(() => store.getDir('terminal', 'a/b')).toThrow(/Invalid account name/)
+    expect(() => store.getDir('terminal', 'a\\b')).toThrow(/Invalid account name/)
+  })
+
+  it('delete with empty name throws instead of wiping every account of the aiType', () => {
+    const store = new storeModule.AccountStore()
+    store.save('terminal', 'work')
+    store.save('terminal', 'personal')
+
+    expect(() => store.delete('terminal', '')).toThrow(/Invalid account name/)
+
+    // Both accounts must survive — '' used to resolve to the aiType root dir.
+    expect(store.list('terminal').sort()).toEqual(['personal', 'work'])
+  })
+
+  it('delete with "." or whitespace-only name throws', () => {
+    const store = new storeModule.AccountStore()
+    store.save('terminal', 'work')
+
+    expect(() => store.delete('terminal', '.')).toThrow(/Invalid account name/)
+    expect(() => store.delete('terminal', '   ')).toThrow(/Invalid account name/)
+
+    expect(store.list('terminal')).toEqual(['work'])
+    expect(existsSync(join(home, '.raven-nest', 'accounts', 'terminal', 'work'))).toBe(true)
+  })
+})

--- a/electron/account-store.ts
+++ b/electron/account-store.ts
@@ -8,7 +8,12 @@ const VALID_AI_TYPES = new Set(['claude', 'gemini', 'codex', 'copilot', 'opencod
 
 function assertSafe(aiType: string, name?: string): void {
   if (!VALID_AI_TYPES.has(aiType)) throw new Error(`Invalid AI type: ${aiType}`)
-  if (name !== undefined && (name.includes('..') || name.includes('/') || name.includes('\\'))) {
+  if (name === undefined) return
+  // '' and '.' resolve to the aiType root itself: delete() with either would
+  // rmSync EVERY account of that type. join() swallows empty segments, so the
+  // traversal checks below never see them.
+  const trimmed = name.trim()
+  if (trimmed === '' || trimmed === '.' || name.includes('..') || name.includes('/') || name.includes('\\')) {
     throw new Error(`Invalid account name: ${name}`)
   }
 }


### PR DESCRIPTION
## Resumen

`accounts:delete` llegaba al `rmSync` recursivo con nombres `''` / `'.'`: ambos resuelven al directorio raíz del aiType (`join()` se traga los segmentos vacíos, así que el chequeo de traversal nunca los veía). Un `undefined` coercionado a `''` en el renderer alcanzaba para borrar TODAS las cuentas de ese tipo. `assertSafe()` ahora rechaza `''`, `'.'` y nombres whitespace-only, además del traversal que ya cubría.

## Verificación

- [x] `npx vitest run electron/__tests__/account-store.test.ts` — 4/4 (2 tests nuevos de guard, TDD: rojos antes del fix; + round-trip y traversal de regresión)
- [x] `npx tsc --noEmit` — limpio
- [ ] Pendiente de validación: smoke manual del flujo de cuentas en la app

## Notas

El mismo patrón de validación de segmentos aplica a otros stores del main process; se revisan por separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)