### PR TITLE
fix(session): escritura atómica + el save debounced ya no pisa la sesión durante el restore

### DIFF
--- a/electron/__tests__/session-store.test.ts
+++ b/electron/__tests__/session-store.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { makeTmpDir, cleanupTmp } from './setup'
+
+describe('session-store', () => {
+  let home: string
+  let mod: typeof import('../session-store')
+
+  beforeEach(async () => {
+    home = makeTmpDir('raven-session-')
+    process.env.RAVEN_HOME = home
+    vi.resetModules()
+    mod = await import('../session-store')
+  })
+
+  afterEach(() => {
+    delete process.env.RAVEN_HOME
+    cleanupTmp(home)
+  })
+
+  const sessionDir = () => join(home, '.raven-nest')
+
+  it('save + load round-trip', () => {
+    const data = { tabs: [{ id: 't1', name: 'Workspace', panes: [] }], activeTabId: 't1' }
+    mod.saveSession(data)
+    expect(mod.loadSession()).toEqual(data)
+  })
+
+  it('load returns null on first launch (no file)', () => {
+    expect(mod.loadSession()).toBeNull()
+  })
+
+  it('load returns null on corrupt file instead of throwing', () => {
+    mkdirSync(sessionDir(), { recursive: true })
+    writeFileSync(join(sessionDir(), 'session.json'), '{truncated')
+    expect(mod.loadSession()).toBeNull()
+  })
+
+  it('a failed save leaves the previous session intact (no partial write)', () => {
+    const good = { tabs: [{ id: 't1' }], activeTabId: 't1' }
+    mod.saveSession(good)
+
+    // JSON.stringify throws on circular data — the write must fail BEFORE
+    // touching session.json, not after truncating it.
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(() => mod.saveSession(circular)).toThrow()
+
+    expect(mod.loadSession()).toEqual(good)
+  })
+
+  it('save does not leave tmp files behind', () => {
+    mod.saveSession({ tabs: [], activeTabId: null })
+    const leftovers = readdirSync(sessionDir()).filter((f) => f !== 'session.json')
+    expect(leftovers).toEqual([])
+  })
+
+  it('save is readable as plain JSON on disk', () => {
+    mod.saveSession({ activeTabId: 'x' })
+    const raw = readFileSync(join(sessionDir(), 'session.json'), 'utf8')
+    expect(JSON.parse(raw)).toEqual({ activeTabId: 'x' })
+  })
+})

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -99,6 +99,7 @@ import { join as pathJoin, join, isAbsolute, basename, dirname } from 'path'
 import { readFileSync, writeFileSync, mkdirSync, statSync, copyFileSync, unlinkSync, rmSync, existsSync, promises as fsp } from 'fs'
 import { tmpdir, homedir } from 'os'
 import { ravenHome, userHome } from './raven-home'
+import { loadSession, saveSession } from './session-store'
 import { execSync, execFile, execFileSync, spawn } from 'child_process'
 import { randomBytes } from 'crypto'
 import { PtyManager } from './pty-manager'
@@ -1944,28 +1945,14 @@ ipcMain.handle('ide:open', async (_evt, binPath: string, worktreePath: string) =
 
 ipcMain.handle('ide:clearCache', async () => { clearIDECache() })
 
-// Session persistence
-const SESSION_PATH = join(ravenHome(), '.raven-nest', 'session.json')
-
-ipcMain.handle('session:load', () => {
-  try {
-    return JSON.parse(readFileSync(SESSION_PATH, 'utf8'))
-  } catch (err) {
-    // ENOENT is the expected "first launch, no session yet" case — return null
-    // silently. Any other error means the session file is corrupt / unreadable;
-    // log loud so we can debug why the user's panes didn't restore.
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
-    console.error('[session:load] failed to read session', SESSION_PATH, err)
-    return null
-  }
-})
+// Session persistence — atomic read/write lives in session-store.ts
+ipcMain.handle('session:load', () => loadSession())
 
 ipcMain.handle('session:save', (_event, data: unknown) => {
   try {
-    mkdirSync(join(ravenHome(), '.raven-nest'), { recursive: true })
-    writeFileSync(SESSION_PATH, JSON.stringify(data))
+    saveSession(data)
   } catch (err) {
-    console.error('[session:save] failed to write session', SESSION_PATH, err)
+    console.error('[session:save] failed to write session', err)
   }
 })
 

--- a/electron/session-store.ts
+++ b/electron/session-store.ts
@@ -1,0 +1,40 @@
+import { join } from 'path'
+import { mkdirSync, readFileSync, writeFileSync, renameSync, rmSync } from 'fs'
+import { ravenHome } from './raven-home'
+
+// Lazy paths (not module-level constants) so tests can point RAVEN_HOME at a
+// tmp dir per test.
+const sessionDir = () => join(ravenHome(), '.raven-nest')
+const sessionPath = () => join(sessionDir(), 'session.json')
+
+export function loadSession(): unknown | null {
+  try {
+    return JSON.parse(readFileSync(sessionPath(), 'utf8'))
+  } catch (err) {
+    // ENOENT is the expected "first launch, no session yet" case — return null
+    // silently. Any other error means the session file is corrupt / unreadable;
+    // log loud so we can debug why the user's panes didn't restore.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    console.error('[session-store] failed to read session', sessionPath(), err)
+    return null
+  }
+}
+
+/**
+ * Atomic save: serialize first (so a stringify error can't touch the file),
+ * write to a tmp sibling, then rename over session.json. A crash mid-write
+ * leaves the previous session intact instead of a truncated JSON that
+ * loadSession() can't parse — that was unrecoverable data loss.
+ */
+export function saveSession(data: unknown): void {
+  const serialized = JSON.stringify(data)
+  mkdirSync(sessionDir(), { recursive: true })
+  const tmp = sessionPath() + '.tmp'
+  try {
+    writeFileSync(tmp, serialized)
+    renameSync(tmp, sessionPath())
+  } catch (err) {
+    try { rmSync(tmp, { force: true }) } catch { /* best effort */ }
+    throw err
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -693,10 +693,18 @@ export default function App() {
     setAddingPane({})
   }, [])
 
+  // Saves must wait until the restore attempt finished: the debounced save
+  // below fires 800ms after mount, and with the initial empty workspace it
+  // would overwrite session.json before the async restore populates the tabs.
+  const sessionRestoredRef = useRef(false)
+
   // Load session on startup
   useEffect(() => {
     window.session.load().then((data) => {
-      if (!data) return
+      if (!data) {
+        sessionRestoredRef.current = true
+        return
+      }
 
       const COLOR_MIGRATION: Record<string, string> = {
         '#3B82F6': '#0055FF', '#EF4444': '#FF1A1A', '#10B981': '#00CC44',
@@ -747,6 +755,7 @@ export default function App() {
           panes: live,
         }])
         setActiveTabId(id)
+        sessionRestoredRef.current = true
         return
       }
 
@@ -780,13 +789,25 @@ export default function App() {
         })).then((cleaned) => {
           setTabs(cleaned)
           setActiveTabId(data.activeTabId ?? cleaned[0].id)
+          sessionRestoredRef.current = true
+        }).catch((err) => {
+          console.error('[session] restore failed; re-enabling saves with current state', err)
+          sessionRestoredRef.current = true
         })
+        return
       }
+
+      // Session exists but has no restorable tabs — nothing to protect.
+      sessionRestoredRef.current = true
+    }).catch(() => {
+      sessionRestoredRef.current = true
     })
   }, [])
 
-  // Save session on changes (debounced 800ms)
+  // Save session on changes (debounced 800ms). Gated until the restore
+  // attempt finishes — see sessionRestoredRef above.
   useEffect(() => {
+    if (!sessionRestoredRef.current) return
     const timer = setTimeout(() => {
       const sessionData: SessionData = {
         tabs: tabs.map(tab => ({


### PR DESCRIPTION
## Resumen

Dos causas de pérdida de sesión, mismo archivo:

- **Main**: `session:save` escribía con `writeFileSync` directo — un crash a mitad de escritura dejaba un JSON truncado que `session:load` no puede parsear (pérdida total, sin recuperación). Extraído a `electron/session-store.ts` (patrón store de la casa): serializa primero, escribe a `.tmp` y renombra (atómico). Un `stringify` que falla ya no toca el archivo.
- **Renderer**: el save debounced de 800ms en `App.tsx` corría con el workspace inicial vacío mientras el restore async (que chequea `path:exists` por repo) seguía en vuelo — si el usuario cerraba en esa ventana, `session.json` quedaba pisado con un workspace vacío. Ahora los saves se gatean con `sessionRestoredRef` hasta que el restore termina (todos los caminos: sin sesión, v1, v2/v3, error).

## Verificación

- [x] `npx vitest run electron/__tests__/session-store.test.ts` — 6/6 (round-trip, corrupto→null, save fallido no toca la sesión previa, sin tmp residual)
- [x] `npx tsc --noEmit` — limpio
- [x] `npm test` — 171 passed; los 4 fails son los preexistentes de entorno macOS (worktree-store symlink /private/var + env de Supabase), verdes en CI Linux
- [ ] Pendiente de validación: smoke manual — abrir con sesión existente, verificar que restaura; crear panes, Cmd+Q, reabrir

## Notas

Cubre dos hallazgos del review interno (save no atómico + race de arranque). Queda aparte el hallazgo del `layoutId` inválido que crashea el render al arrancar — es otro fix, otro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)