### PR TITLE
fix(pty): accountDir/.local/bin en el PATH de panes AI en Mac

### DIFF
--- a/electron/pty-manager.ts
+++ b/electron/pty-manager.ts
@@ -52,6 +52,13 @@ export class PtyManager extends EventEmitter {
     if (isMac) {
       const home = env.HOME || ''
       const extra = [
+        // AI panes redirect HOME to accountDir (see below), and the native
+        // `claude` installer drops its launcher at $HOME/.local/bin =
+        // accountDir/.local/bin. Claude's /doctor checks `homedir()/.local/bin`
+        // ∈ PATH, so without this entry it warns "Native installation exists
+        // but ~/.local/bin is not in your PATH". Prepend it so the per-account
+        // install is found and preferred over any stray global claude.
+        ...(accountDir && cmd ? [`${accountDir}/.local/bin`] : []),
         `${home}/.local/bin`,
         '/opt/homebrew/bin',
         '/opt/homebrew/sbin',


### PR DESCRIPTION
## Resumen

Los panes de AI redirigen HOME al accountDir, y el instalador nativo de `claude` deja su launcher en `$HOME/.local/bin` = `accountDir/.local/bin`. Sin esa entrada en el PATH, `/doctor` warnea "Native installation exists but ~/.local/bin is not in your PATH" y puede agarrar un claude global viejo. Se antepone la ruta por-cuenta (solo Mac, solo si hay accountDir+cmd).

## Verificación

- [x] `npx tsc --noEmit` — limpio
- [ ] Pendiente de validación: smoke con cuenta que tenga claude nativo instalado (Gero)

## Notas

Fix chico que venía sin commitear en el working tree de feat/integrations; va solo para no mezclarlo con el feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)