### PR TITLE
fix(rls): políticas UPDATE/DELETE de líder sobre team_members sin recursión

### DIFF
--- a/supabase/migrations/024_fix_leader_policy_recursion.sql
+++ b/supabase/migrations/024_fix_leader_policy_recursion.sql
@@ -1,0 +1,30 @@
+-- 024: Fix infinite recursion in team_members leader UPDATE and DELETE policies
+--
+-- Migration 007 "Team leader can update members" and migration 20260511050000
+-- "Team leader can delete members" both contain direct self-referential subqueries:
+--
+--   team_id IN (SELECT team_id FROM team_members
+--               WHERE user_id = auth.uid() AND role = 'leader' AND status = 'active')
+--
+-- When these policies are evaluated, the inner SELECT on team_members triggers
+-- the SELECT RLS policies on team_members from within the UPDATE/DELETE policy
+-- evaluation — hitting Postgres' recursion guard.
+--
+-- Fix: replace both policies using _is_team_leader() (migration 022), which is
+-- SECURITY DEFINER SET row_security = OFF and thus bypasses RLS internally.
+
+DROP POLICY IF EXISTS "Team leader can update members" ON team_members;
+
+CREATE POLICY "Team leader can update members"
+  ON team_members FOR UPDATE USING (
+    _is_team_leader(team_members.team_id)
+  );
+
+DROP POLICY IF EXISTS "Team leader can delete members" ON team_members;
+
+CREATE POLICY "Team leader can delete members"
+  ON team_members FOR DELETE USING (
+    _is_team_leader(team_members.team_id)
+    AND user_id <> (SELECT owner_id FROM teams WHERE id = team_members.team_id)
+    AND user_id <> auth.uid()
+  );


### PR DESCRIPTION
## Resumen

Las políticas "Team leader can update/delete members" (migraciones 007 y 20260511050000) tienen subqueries self-referenciales sobre `team_members` que disparan las políticas SELECT de la misma tabla durante su evaluación — recursión infinita cortada por el guard de Postgres. Se reemplazan usando `_is_team_leader()` (SECURITY DEFINER con row_security OFF, migración 022), mismo patrón que el fix de la 020.

## Verificación

- [x] Idempotente: `DROP POLICY IF EXISTS` + `CREATE` — re-aplicable sin efecto si ya corrió a mano en prod
- [ ] Pendiente de validación: aplicar en Supabase local (`supabase db reset`) y probar update/delete de miembros como líder — la hago antes del merge

## Notas

Migración que estaba suelta sin commitear en el working tree. Numeración: `main` va por 023, así que 024 queda libre (el PR #12 externo también propone un 024 — si se acepta, se renumera ese).

🤖 Generated with [Claude Code](https://claude.com/claude-code)