### PR TITLE
feat(hub): el Hub como workspace con layout real + pin transversal

### DIFF
--- a/docs/superpowers/plans/2026-07-14-hub-overlay.md
+++ b/docs/superpowers/plans/2026-07-14-hub-overlay.md
@@ -1,0 +1,1091 @@
+# Hub Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Overlay "Hub" (`Ctrl/Cmd+Shift+O`) que muestra en grilla todas las terminales vivas de todos los workspaces y permite escribir en cualquiera; `Esc` vuelve al pane previo.
+
+**Architecture:** La grilla (`HubGrid`) es un componente puro reutilizable; el contenedor (`HubOverlay`) es un estado de UI en `App` (mismo patrón que CommandPalette/GlobalSearch). Cada tile monta su propio xterm conectado al PTY existente por `paneId` vía `subscribeToPtyData` + `getBuffer` — nunca crea ni mata PTYs. Spec: `docs/superpowers/specs/2026-07-14-hub-overlay-design.md`.
+
+**Tech Stack:** Electron + Vite + React + TypeScript (strict), xterm.js (`@xterm/xterm` + `@xterm/addon-fit`), node-pty ya existente en main. **Sin dependencias nuevas.**
+
+## Global Constraints
+
+- Rama: `feat/hub-overlay` (worktree `C:\Users\matia\raven-nest-wt\feat-hub-overlay`). **PROHIBIDO** pushear a `main` o mergear; el entregable final es un PR draft para review de Gero.
+- TypeScript strict: `npm run build` debe pasar limpio después de CADA tarea (es el type-gate del repo; no hay suite de tests automatizada — CONTRIBUTING pide ejercitar la feature en la app real con `npm run dev` y documentar el test path manual).
+- Estilos: solo tokens existentes (`--raven-blue`, `--bg-*`, `--border`, `--text-*`, `--pane-color`). Cero colores nuevos hardcodeados (salvo los ya presentes en el codebase, p. ej. `#22C55E` del activity dot, referenciados tal cual).
+- Reglas duras de convivencia con el código existente:
+  - **NUNCA** llamar `registerPane()` desde el Hub (es un `Map` de callback único por pane: pisaría el callback del `TerminalPane` del workspace activo). Usar `subscribeToPtyData()`.
+  - **NUNCA** llamar `registerTerminal()` desde el Hub (pisaría la instancia del pane real en el registry de GlobalSearch).
+  - **NUNCA** matar PTYs al desmontar tiles (`term.dispose()` sí, `pty.kill` jamás).
+  - Resize de PTY: solo el tile enfocado y solo si su pane NO pertenece al tab activo (esos panes están montados a tamaño real detrás del overlay).
+- Panes `aiType === 'browser'` quedan fuera del Hub (no tienen PTY).
+- Commits: estilo del repo, cortos e imperativos, con `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+## File Structure
+
+- Create: `src/hooks/useHubTerminal.ts` — xterm liviano para tiles (replay + stream + input; sin search/weblinks/registry).
+- Create: `src/components/HubTile.tsx` — tile individual (header + xterm + pin + ended).
+- Create: `src/components/HubGrid.tsx` — grilla pura + tipos `HubEntry`/`HubFilter` + `filterEntries()`.
+- Create: `src/components/HubOverlay.tsx` — contenedor overlay (filtros, paginación, teclado, foco).
+- Modify: `src/types.ts` — `pinned?: boolean` en `PaneNode` (línea ~40) y `SessionPane` (línea ~220).
+- Modify: `src/lib/keybindings.ts` — binding `hubOverlay`.
+- Modify: `src/components/CommandPalette.tsx` — prop `onHubOpen` + item de acción.
+- Modify: `src/App.tsx` — estado `hubOpen`, handlers, keybind, botón en tab bar, persistencia de `pinned`.
+- Modify: `src/styles/global.css` — sección `/* ── Hub Overlay ── */` al final.
+
+---
+
+### Task 1: Tipos, keybinding y persistencia de `pinned`
+
+**Files:**
+- Modify: `src/types.ts` (interfaces `PaneNode` y `SessionPane`)
+- Modify: `src/lib/keybindings.ts` (interface `Keybindings` + `DEFAULT_SETTINGS`)
+- Modify: `src/App.tsx` (mapeo de save de sesión, ~línea 819)
+
+**Interfaces:**
+- Produces: `PaneNode.pinned?: boolean`, `SessionPane.pinned?: boolean`, `kb.hubOverlay` (binding `'Meta+Shift+O'` → Ctrl en Win/Linux, ⌘ en Mac). `sessionToPane` ya spreadea `...sp`, así que `pinned` fluye solo en el restore.
+
+- [ ] **Step 1: Agregar `pinned` a `PaneNode`**
+
+En `src/types.ts`, dentro de `interface PaneNode` (después de `shellId?: string`):
+
+```ts
+  shellId?: string      // terminal panes only: which shell to spawn (Windows shell picker)
+  pinned?: boolean      // Hub: user-pinned pane, shows under the "Pinned" filter
+```
+
+- [ ] **Step 2: Agregar `pinned` a `SessionPane`**
+
+En `src/types.ts`, dentro de `interface SessionPane` (después de `url?: string`):
+
+```ts
+  url?: string  // browser only: last navigated URL, restored on session load
+  pinned?: boolean  // Hub pin — survives session restore
+```
+
+- [ ] **Step 3: Persistir `pinned` en el save de sesión**
+
+En `src/App.tsx`, en el `useEffect` de save (~línea 819), el mapeo `panes: tab.panes.map(p => ({ ... }))` — agregar después de `shellId: p.shellId,`:
+
+```ts
+            shellId: p.shellId,
+            pinned: p.pinned,
+```
+
+(El restore no necesita cambios: `sessionToPane` hace `...sp`.)
+
+- [ ] **Step 4: Agregar keybinding `hubOverlay`**
+
+En `src/lib/keybindings.ts`:
+
+```ts
+export interface Keybindings {
+  voiceInput: string
+  newPane: string
+  globalSearch: string
+  commandPalette: string
+  hubOverlay: string
+  nextPane: string
+  // ... resto igual
+```
+
+y en `DEFAULT_SETTINGS.keybindings`, después de `commandPalette: 'Meta+k',`:
+
+```ts
+    commandPalette: 'Meta+k',
+    hubOverlay: 'Meta+Shift+O',
+```
+
+Nota: `useSettings` mergea `{ ...DEFAULT_SETTINGS.keybindings, ...s.keybindings }`, así que settings guardados viejos toman el default automáticamente.
+
+- [ ] **Step 5: Verificar type-check**
+
+Run: `npm run build`
+Expected: build OK, sin errores TS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types.ts src/lib/keybindings.ts src/App.tsx
+git commit -m "feat(hub): pinned en PaneNode/SessionPane + keybinding hubOverlay
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Hook `useHubTerminal`
+
+**Files:**
+- Create: `src/hooks/useHubTerminal.ts`
+
+**Interfaces:**
+- Consumes: `subscribeToPtyData` (`src/pty-events.ts:35`), `window.pty.getBuffer/write/resize`.
+- Produces: `useHubTerminal(paneId: string, canResizePty: boolean): { containerRef: React.RefObject<HTMLDivElement>, focusTile: () => void }`. `canResizePty` = el pane NO pertenece al tab activo.
+
+- [ ] **Step 1: Crear el hook completo**
+
+`src/hooks/useHubTerminal.ts`:
+
+```ts
+import { useEffect, useRef, useCallback } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { subscribeToPtyData } from '../pty-events'
+
+// Replay only the tail of the 10k-line main-process buffer — a compact tile
+// doesn't need full scroll-back and writing 10k lines × 12 tiles at once
+// would jank the overlay open animation.
+const TAIL_LINES = 200
+
+/**
+ * Lightweight xterm for Hub tiles. Attaches to an EXISTING PTY by paneId:
+ * replays the buffer tail, subscribes to the global data bus, forwards input.
+ * Never creates or kills the PTY, never touches the pane registries
+ * (registerPane/registerTerminal are single-slot per paneId and belong to
+ * the real TerminalPane).
+ *
+ * PTY resize policy: only when `canResizePty` (pane is NOT in the active
+ * tab — active-tab panes stay mounted at real size behind the overlay) and
+ * only when this tile owns keyboard focus.
+ */
+export function useHubTerminal(paneId: string, canResizePty: boolean) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
+  const canResizeRef = useRef(canResizePty)
+  canResizeRef.current = canResizePty
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const fontFamily = window.platform?.isMac
+      ? '"SF Mono", "Menlo", "Monaco", monospace'
+      : '"Cascadia Mono", "Cascadia Code", "Consolas", monospace'
+
+    const term = new Terminal({
+      fontFamily,
+      fontSize: 11,
+      lineHeight: 1.3,
+      cursorBlink: false,
+      cursorStyle: 'bar',
+      scrollback: 1000,
+      theme: {
+        background: '#000000',
+        foreground: '#e8e8e8',
+        cursor: '#0066FF',
+        selectionBackground: '#0066FF33',
+      },
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(container)
+    termRef.current = term
+    fitRef.current = fit
+
+    // Fit the xterm view to the tile WITHOUT resizing the PTY — view-only.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        try { fit.fit() } catch { /* ignore */ }
+      })
+    })
+
+    let alive = true
+    window.pty.getBuffer(paneId).then((buf) => {
+      if (!alive || !buf) return
+      const tail = buf.split('\n').slice(-TAIL_LINES).join('\n')
+      term.write(tail)
+    })
+
+    const unsubscribe = subscribeToPtyData((id, data) => {
+      if (id === paneId) term.write(data)
+    })
+
+    // Input flows only when this xterm has DOM focus — xterm only emits
+    // onData for the focused instance, so no extra gating is needed.
+    term.onData((data) => window.pty.write(paneId, data))
+
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        try {
+          if (!container.clientWidth || !container.clientHeight) return
+          fit.fit()
+          if (canResizeRef.current && container.contains(document.activeElement)) {
+            window.pty.resize(paneId, term.cols, term.rows)
+          }
+        } catch { /* ignore */ }
+      })
+    })
+    resizeObserver.observe(container)
+
+    return () => {
+      alive = false
+      unsubscribe()
+      resizeObserver.disconnect()
+      // Do NOT kill the PTY — same contract as TerminalPane.
+      term.dispose()
+    }
+  }, [paneId])
+
+  const focusTile = useCallback(() => {
+    const term = termRef.current
+    if (!term) return
+    term.focus()
+    if (canResizeRef.current && fitRef.current) {
+      try {
+        fitRef.current.fit()
+        window.pty.resize(paneId, term.cols, term.rows)
+      } catch { /* ignore */ }
+    }
+  }, [paneId])
+
+  return { containerRef, focusTile }
+}
+```
+
+- [ ] **Step 2: Verificar type-check**
+
+Run: `npm run build`
+Expected: OK (el hook aún no se usa; no debe romper nada).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useHubTerminal.ts
+git commit -m "feat(hub): useHubTerminal — xterm liviano adosado a PTY existente
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `HubGrid` (tipos + filtro puro + grilla) y `HubTile`
+
+**Files:**
+- Create: `src/components/HubGrid.tsx`
+- Create: `src/components/HubTile.tsx`
+
+**Interfaces:**
+- Consumes: `useHubTerminal(paneId, canResizePty)` (Task 2), `PaneNode`/`AI_CONFIG` de `../types`.
+- Produces (usados por Task 4):
+  - `interface HubEntry { pane: PaneNode; tabId: string; tabName: string; isActiveTab: boolean; busy: boolean }`
+  - `type HubFilter = 'all' | 'active' | 'pinned' | { tabId: string }`
+  - `function filterEntries(entries: HubEntry[], filter: HubFilter): HubEntry[]`
+  - `<HubGrid entries focusedPaneId onFocus onJump onTogglePin />`
+
+- [ ] **Step 1: Crear `src/components/HubGrid.tsx`**
+
+```tsx
+import { PaneNode } from '../types'
+import HubTile from './HubTile'
+
+export interface HubEntry {
+  pane: PaneNode
+  tabId: string
+  tabName: string
+  isActiveTab: boolean
+  busy: boolean
+}
+
+export type HubFilter = 'all' | 'active' | 'pinned' | { tabId: string }
+
+export function filterEntries(entries: HubEntry[], filter: HubFilter): HubEntry[] {
+  if (filter === 'all') return entries
+  if (filter === 'active') return entries.filter(e => e.busy)
+  if (filter === 'pinned') return entries.filter(e => e.pane.pinned)
+  return entries.filter(e => e.tabId === filter.tabId)
+}
+
+interface Props {
+  entries: HubEntry[]
+  focusedPaneId: string | null
+  onFocus: (paneId: string) => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubGrid({ entries, focusedPaneId, onFocus, onJump, onTogglePin }: Props) {
+  if (entries.length === 0) {
+    return <div className="hub-empty">No hay terminales para este filtro</div>
+  }
+  return (
+    <div className="hub-grid">
+      {entries.map(e => (
+        <HubTile
+          key={e.pane.id}
+          entry={e}
+          focused={focusedPaneId === e.pane.id}
+          onFocus={onFocus}
+          onJump={onJump}
+          onTogglePin={onTogglePin}
+        />
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Crear `src/components/HubTile.tsx`**
+
+```tsx
+import { useEffect, useState } from 'react'
+import { AI_CONFIG } from '../types'
+import { useHubTerminal } from '../hooks/useHubTerminal'
+import type { HubEntry } from './HubGrid'
+
+interface Props {
+  entry: HubEntry
+  focused: boolean
+  onFocus: (paneId: string) => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubTile({ entry, focused, onFocus, onJump, onTogglePin }: Props) {
+  const { pane, tabId, tabName, isActiveTab, busy } = entry
+  // Active-tab panes stay mounted at real size behind the overlay — never
+  // resize their PTY from a tile (see spec: "tamaño del PTY").
+  const { containerRef, focusTile } = useHubTerminal(pane.id, !isActiveTab)
+  const [ended, setEnded] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    window.pty.exists(pane.id).then(exists => { if (alive) setEnded(!exists) })
+    return () => { alive = false }
+  }, [pane.id])
+
+  // External focus (Tab cycling from HubOverlay) → focus the xterm too
+  useEffect(() => {
+    if (focused) focusTile()
+  }, [focused, focusTile])
+
+  const aiColor = pane.borderColor ?? pane.customColor ?? AI_CONFIG[pane.aiType]?.color ?? '#888888'
+  const aiLabel = pane.customLabel ?? AI_CONFIG[pane.aiType].label
+
+  return (
+    <div
+      className={`hub-tile${focused ? ' focused' : ''}`}
+      style={{ '--pane-color': aiColor } as React.CSSProperties}
+      onMouseDown={() => { onFocus(pane.id); focusTile() }}
+      onDoubleClick={() => onJump(tabId, pane.id)}
+    >
+      <div className="hub-tile-header">
+        <span className="pane-color-btn" style={{ background: aiColor, cursor: 'default' }} />
+        <span className="pane-ai-label" style={{ color: aiColor }}>{aiLabel}</span>
+        {pane.accountName && !AI_CONFIG[pane.aiType]?.noAccount && (
+          <span className="pane-account-name">{pane.accountName}</span>
+        )}
+        <span className="hub-tile-ws" title={`Workspace: ${tabName}`}>{tabName}</span>
+        {busy && !ended && <span className="hub-tile-busy" />}
+        {ended && <span className="pane-ended-badge">ended</span>}
+        <span className="hub-tile-spacer" />
+        <button
+          className={`hub-tile-pin${pane.pinned ? ' pinned' : ''}`}
+          title={pane.pinned ? 'Quitar pin' : 'Pinear al Hub'}
+          onClick={(e) => { e.stopPropagation(); onTogglePin(tabId, pane.id) }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          pin
+        </button>
+      </div>
+      <div ref={containerRef} className="hub-tile-terminal" />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Verificar type-check**
+
+Run: `npm run build`
+Expected: OK. (Las clases CSS todavía no existen — se agregan en Task 4; no afecta el build.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/HubGrid.tsx src/components/HubTile.tsx
+git commit -m "feat(hub): HubGrid + HubTile — grilla reutilizable de terminales
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `HubOverlay` (filtros, paginación, teclado) + CSS
+
+**Files:**
+- Create: `src/components/HubOverlay.tsx`
+- Modify: `src/styles/global.css` (nueva sección al final del archivo)
+
+**Interfaces:**
+- Consumes: `HubEntry`, `HubFilter`, `filterEntries`, `HubGrid` (Task 3); `WorkspaceTab` de `../types`.
+- Produces (consumido por Task 5): `<HubOverlay tabs activeTabId busyPanes onClose onJump onTogglePin />` con `onJump: (tabId: string, paneId: string) => void`, `onTogglePin: (tabId: string, paneId: string) => void`.
+
+- [ ] **Step 1: Crear `src/components/HubOverlay.tsx`**
+
+```tsx
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { WorkspaceTab } from '../types'
+import HubGrid, { HubEntry, HubFilter, filterEntries } from './HubGrid'
+import { formatBinding } from '../lib/keybindings'
+
+const PAGE_SIZE = 12
+const FILTER_STORAGE_KEY = 'nest-hub-filter'
+
+function loadFilter(): HubFilter {
+  const raw = localStorage.getItem(FILTER_STORAGE_KEY)
+  if (raw === 'active' || raw === 'pinned') return raw
+  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
+  return 'all'
+}
+
+function saveFilter(f: HubFilter) {
+  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+}
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  busyPanes: Set<string>
+  onClose: () => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubOverlay({ tabs, activeTabId, busyPanes, onClose, onJump, onTogglePin }: Props) {
+  const [filter, setFilter] = useState<HubFilter>(loadFilter)
+  const [page, setPage] = useState(0)
+  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
+
+  const entries = useMemo<HubEntry[]>(() =>
+    tabs.flatMap(t =>
+      t.panes
+        .filter(p => p.aiType !== 'browser')
+        .map(p => ({
+          pane: p,
+          tabId: t.id,
+          tabName: t.name,
+          isActiveTab: t.id === activeTabId,
+          busy: busyPanes.has(p.id),
+        }))
+    ), [tabs, activeTabId, busyPanes])
+
+  const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const visible = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const changeFilter = useCallback((f: HubFilter) => {
+    setFilter(f)
+    setPage(0)
+    saveFilter(f)
+  }, [])
+
+  // If the focused pane left the visible set (filter change, pane closed),
+  // drop focus so Tab cycling restarts from the first tile.
+  useEffect(() => {
+    if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
+      setFocusedPaneId(null)
+    }
+  }, [visible, focusedPaneId])
+
+  // Keyboard: Tab cycles tiles; Enter jumps to the focused pane's workspace.
+  // Escape is handled centrally in App.tsx (capture phase) so overlay
+  // priority lives in one place.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        if (visible.length === 0) return
+        const idx = visible.findIndex(en => en.pane.id === focusedPaneId)
+        const next = e.shiftKey
+          ? (idx - 1 + visible.length) % visible.length
+          : (idx + 1) % visible.length
+        setFocusedPaneId(visible[next].pane.id)
+        return
+      }
+      if (e.key === 'Enter' && focusedPaneId) {
+        const entry = visible.find(en => en.pane.id === focusedPaneId)
+        // Only when the xterm itself isn't consuming Enter (i.e. the tile is
+        // focused via Tab but the user hasn't clicked into the terminal).
+        if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
+          e.preventDefault()
+          onJump(entry.tabId, entry.pane.id)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [visible, focusedPaneId, onJump])
+
+  const counts = useMemo(() => ({
+    all: entries.length,
+    active: entries.filter(e => e.busy).length,
+    pinned: entries.filter(e => e.pane.pinned).length,
+  }), [entries])
+
+  const filterIs = (f: HubFilter) =>
+    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
+
+  return (
+    <div className="hub-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="hub-panel">
+        <div className="hub-title">
+          <span>Hub — terminales activas</span>
+          <span className="hub-title-hint">
+            Esc volver · Tab siguiente · Enter ir al workspace · {formatBinding('Meta+Shift+O')} toggle
+          </span>
+        </div>
+        <div className="hub-toolbar">
+          <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
+            Todas <span className="hub-chip-n">{counts.all}</span>
+          </button>
+          <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
+            Activas <span className="hub-chip-n">{counts.active}</span>
+          </button>
+          <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
+            Pineadas <span className="hub-chip-n">{counts.pinned}</span>
+          </button>
+          <span className="hub-toolbar-sep" />
+          {tabs.map(t => (
+            <button
+              key={t.id}
+              className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
+              onClick={() => changeFilter({ tabId: t.id })}
+            >
+              {t.name}
+            </button>
+          ))}
+          {pageCount > 1 && (
+            <span className="hub-pager">
+              <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
+              <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
+              <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
+            </span>
+          )}
+        </div>
+        <HubGrid
+          entries={visible}
+          focusedPaneId={focusedPaneId}
+          onFocus={setFocusedPaneId}
+          onJump={onJump}
+          onTogglePin={onTogglePin}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Agregar CSS al final de `src/styles/global.css`**
+
+```css
+/* ── Hub Overlay ─────────────────────────────────────────── */
+
+.hub-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+}
+
+.hub-panel {
+  width: 100%;
+  height: 100%;
+  max-width: 1400px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.75);
+  overflow: hidden;
+}
+
+.hub-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  user-select: none;
+}
+
+.hub-title-hint {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.hub-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  user-select: none;
+}
+
+.hub-chip {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.hub-chip:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.hub-chip.on {
+  color: var(--raven-blue);
+  background: #0066FF15;
+  border-color: #0066FF30;
+}
+
+.hub-chip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.hub-chip-n {
+  color: var(--text-muted);
+  margin-left: 3px;
+}
+
+.hub-chip.on .hub-chip-n {
+  color: var(--text-secondary);
+}
+
+.hub-toolbar-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--border);
+  margin: 0 3px;
+}
+
+.hub-pager {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hub-pager-label {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.hub-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-auto-rows: minmax(180px, 1fr);
+  gap: 6px;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.hub-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hub-tile {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-app);
+  border: 1.5px solid color-mix(in srgb, var(--pane-color, var(--border)) 40%, transparent);
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 12%, transparent);
+}
+
+.hub-tile.focused {
+  border-color: color-mix(in srgb, var(--pane-color, var(--raven-blue)) 85%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 25%, transparent),
+              0 0 12px -2px color-mix(in srgb, var(--pane-color, transparent) 45%, transparent);
+}
+
+.hub-tile-header {
+  height: 26px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 8px;
+  background: color-mix(in srgb, var(--pane-color, var(--bg-surface)) 8%, var(--bg-surface));
+  font-size: 10px;
+  user-select: none;
+}
+
+.hub-tile-header .pane-ai-label {
+  font-size: 10px;
+}
+
+.hub-tile-header .pane-account-name {
+  font-size: 10px;
+}
+
+.hub-tile-ws {
+  font-size: 9px;
+  font-weight: 600;
+  font-family: 'SF Mono', 'Menlo', monospace;
+  letter-spacing: 0.4px;
+  color: var(--raven-blue);
+  background: #0066FF15;
+  border: 1px solid #0066FF30;
+  border-radius: 3px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-tile-busy {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22C55E;
+  flex-shrink: 0;
+  animation: activityPulse 1.5s ease-in-out infinite;
+}
+
+.hub-tile-spacer {
+  flex: 1;
+}
+
+.hub-tile-pin {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  padding: 1px 5px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.hub-tile-pin:hover {
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.hub-tile-pin.pinned {
+  color: var(--raven-blue);
+  border-color: #0066FF30;
+  background: #0066FF15;
+}
+
+.hub-tile-terminal {
+  flex: 1;
+  min-height: 0;
+  padding: 4px 6px;
+  overflow: hidden;
+}
+
+/* Botón Hub en la tab bar (va dentro del rightSlot, zona no-drag) */
+.hub-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  transition: color 0.15s, border-color 0.15s;
+  position: relative;
+}
+
+.hub-btn:hover {
+  color: var(--raven-blue);
+  border-color: #0066FF44;
+}
+```
+
+- [ ] **Step 3: Verificar type-check**
+
+Run: `npm run build`
+Expected: OK (HubOverlay aún sin montar).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/HubOverlay.tsx src/styles/global.css
+git commit -m "feat(hub): HubOverlay — filtros, paginación y teclado + estilos
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Integración en `App.tsx` + Command Palette + botón en tab bar
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/components/CommandPalette.tsx`
+
+**Interfaces:**
+- Consumes: `HubOverlay` (Task 4), `kb.hubOverlay` (Task 1), `focusTerminal` (`src/terminal-registry.ts`).
+- Produces: feature completa montada.
+
+- [ ] **Step 1: Import + estado en `App.tsx`**
+
+Import (junto a los otros components, ~línea 27):
+
+```ts
+import HubOverlay from './components/HubOverlay'
+```
+
+Estado (junto a `commandPaletteOpen`, ~línea 102):
+
+```ts
+  const [hubOpen, setHubOpen] = useState(false)
+  const hubOpenRef = useRef(false)
+  hubOpenRef.current = hubOpen
+  const hubPrevFocusRef = useRef<string | null>(null)
+```
+
+- [ ] **Step 2: Handlers open/close/jump/pin en `App.tsx`**
+
+Después de `handleTabSelect` (~línea 557):
+
+```ts
+  const openHub = useCallback(() => {
+    hubPrevFocusRef.current = focusedPaneIdRef.current
+    setHubOpen(true)
+  }, [])
+
+  const closeHub = useCallback(() => {
+    setHubOpen(false)
+    const prev = hubPrevFocusRef.current
+    // Restore focus after the overlay unmounts and the pane below re-renders.
+    if (prev) setTimeout(() => focusTerminal(prev), 50)
+  }, [])
+
+  const handleHubJump = useCallback((tabId: string, paneId: string) => {
+    setHubOpen(false)
+    setActiveTabId(tabId)
+    setFocusedPaneId(paneId)
+    focusedPaneIdRef.current = paneId
+    // The pane's xterm mounts on tab switch; focus once it registered.
+    setTimeout(() => focusTerminal(paneId), 150)
+  }, [])
+
+  const handleHubTogglePin = useCallback((tabId: string, paneId: string) => {
+    setTabs(prev => prev.map(t => t.id !== tabId ? t : {
+      ...t,
+      panes: t.panes.map(p => p.id !== paneId ? p : { ...p, pinned: !p.pinned }),
+    }))
+  }, [])
+```
+
+- [ ] **Step 3: Keybinding + Escape en el handler global de `App.tsx`**
+
+En el handler de keydown (~línea 851), ANTES de la línea del Escape de zoom:
+
+```ts
+      if (e.key === 'Escape' && hubOpenRef.current) { closeHub(); return }
+      if (e.key === 'Escape' && zoomedPaneIdRef.current !== null) { handleUnzoom(); return }
+```
+
+Y junto a los bindings de search/palette (~línea 894):
+
+```ts
+      if (matchesBinding(e, kb.globalSearch)) { e.preventDefault(); setGlobalSearchOpen(true); return }
+      if (matchesBinding(e, kb.commandPalette)) { e.preventDefault(); setCommandPaletteOpen(v => !v); return }
+      if (matchesBinding(e, kb.hubOverlay)) {
+        e.preventDefault()
+        if (hubOpenRef.current) closeHub()
+        else openHub()
+        return
+      }
+```
+
+El `useEffect` del handler debe incluir `closeHub` y `openHub` en su array de deps si ya lista callbacks (verificar el array existente y sumarlos si corresponde; si usa refs y `// eslint-disable`, seguir el patrón del archivo).
+
+- [ ] **Step 4: Montar el overlay en el render de `App.tsx`**
+
+Después del bloque `{globalSearchOpen && (...)}` (~línea 1179):
+
+```tsx
+      {hubOpen && (
+        <HubOverlay
+          tabs={tabs}
+          activeTabId={activeTabId}
+          busyPanes={busyPanes}
+          onClose={closeHub}
+          onJump={handleHubJump}
+          onTogglePin={handleHubTogglePin}
+        />
+      )}
+```
+
+- [ ] **Step 5: Botón Hub en la tab bar (via `rightSlot`, sin tocar TabBar)**
+
+Derivar actividad remota (cerca de `activePanesPayload`, ~línea 974):
+
+```ts
+  const hubHasRemoteActivity = useMemo(
+    () => tabs.some(t => t.id !== activeTabId && t.panes.some(p => busyPanes.has(p.id))),
+    [tabs, activeTabId, busyPanes]
+  )
+```
+
+Reemplazar `rightSlot={<ResourceBar panes={activePanesPayload} />}` por:
+
+```tsx
+        rightSlot={
+          <>
+            <button className="hub-btn" onClick={openHub} title={`Hub (${formatBinding('Meta+Shift+O')})`}>
+              Hub
+              {hubHasRemoteActivity && <span className="tab-activity-dot" />}
+            </button>
+            <ResourceBar panes={activePanesPayload} />
+          </>
+        }
+```
+
+Import de `formatBinding` (sumar al import existente de `./lib/keybindings`):
+
+```ts
+import { matchesBinding, formatBinding } from './lib/keybindings'
+```
+
+- [ ] **Step 6: Entrada en Command Palette**
+
+En `src/components/CommandPalette.tsx` — agregar prop:
+
+```ts
+interface Props {
+  // ... existentes
+  onBroadcastToggle: () => void
+  onHubOpen: () => void
+}
+```
+
+En la destructuración del componente sumar `onHubOpen`, y en `buildItems()` después del item `action-broadcast`:
+
+```ts
+    items.push({
+      id: 'action-hub', section: 'actions',
+      label: 'Hub: ver todas las terminales',
+      sublabel: 'Vista compacta de todos los workspaces',
+      keywords: 'hub overview terminales workspaces todas',
+      action: () => { onHubOpen(); onClose() },
+    })
+```
+
+En `App.tsx`, en el JSX de `<CommandPalette ...>` agregar:
+
+```tsx
+          onBroadcastToggle={() => setBroadcastMode(v => !v)}
+          onHubOpen={openHub}
+```
+
+- [ ] **Step 7: Verificar type-check**
+
+Run: `npm run build`
+Expected: OK sin errores.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/App.tsx src/components/CommandPalette.tsx
+git commit -m "feat(hub): integración — atajo, overlay montado, palette y botón en tab bar
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Verificación manual end-to-end + screenshots + PR draft
+
+**Files:**
+- Ninguno nuevo (fixes que surjan del testeo van acá, commiteados por separado).
+
+- [ ] **Step 1: Levantar la app**
+
+Run: `npm run dev` (en el worktree). Expected: app abre.
+
+- [ ] **Step 2: Test path manual (documentarlo tal cual en el PR)**
+
+1. Crear 3 workspaces con 2 terminales c/u (mezclar Claude/terminal plano).
+2. En workspace 1, dejar un agente generando output largo. Cambiar a workspace 2.
+3. `Ctrl+Shift+O` → el Hub abre, se ven las 6 terminales con su chip de workspace; la del agente muestra el punto verde y streamea en vivo.
+4. Click en una terminal del workspace 3 → tipear `echo hola` + Enter → verificar el eco en el tile. Ir al workspace 3 y confirmar que el comando corrió ahí.
+5. `Esc` → vuelve al workspace 2 con el foco en el pane que estaba enfocado antes de abrir.
+6. Reabrir Hub → doble click en un tile de otro workspace → salta a ese workspace con ese pane enfocado.
+7. Pinear 2 terminales → filtro «Pineadas» muestra solo esas → cerrar y reabrir la app → los pins persisten.
+8. Filtro «Activas» muestra solo las busy. Filtro por workspace funciona. Filtro queda recordado al reabrir el Hub.
+9. Matar un proceso (`exit` en un shell) → su tile muestra el badge «ended».
+10. Command Palette (`Ctrl+K`) → «Hub: ver todas las terminales» abre el overlay. Botón «Hub» de la tab bar también, y muestra el puntito verde cuando hay actividad en un workspace no activo.
+11. Con >12 terminales, aparece paginación y navega bien.
+12. Regresión: el broadcast del workspace activo, zoom (`Ctrl+Shift+Z`), Cmd+1-9 y la búsqueda global siguen funcionando igual con el Hub cerrado.
+
+- [ ] **Step 3: Screenshots**
+
+Capturar: (a) Hub abierto con 6+ tiles y filtros, (b) tile enfocado recibiendo input, (c) botón Hub con activity dot. Guardarlas para el body del PR.
+
+- [ ] **Step 4: `npm run build` final**
+
+Run: `npm run build`
+Expected: OK.
+
+- [ ] **Step 5: Push y PR draft (NO mergear)**
+
+```bash
+git push -u origin feat/hub-overlay
+gh pr create --draft --repo GeronimoDiClemente/raven-nest \
+  --title "feat(hub): overlay con todas las terminales de todos los workspaces" \
+  --body-file docs/superpowers/team-stats-PR-body.md
+```
+
+(El body se escribe a mano en ese paso — no reusar el de team-stats; incluir: el *why*, screenshots, el test path manual del Step 2, la decisión de resize de PTY, y el checklist del spec. Cerrar con la línea de generado con Claude Code según convención.)
+
+- [ ] **Step 6: Avisar a Matías**
+
+Reportar URL del PR draft. Recordar: review de Gero; pedir smoke en Mac/Linux en el body.
+
+---
+
+## Self-Review (hecho al escribir el plan)
+
+1. **Cobertura del spec:** entrada por atajo/palette/botón ✓ (Task 5), tiles con lenguaje visual + chip ✓ (Task 3/4), filtros + persistencia localStorage ✓ (Task 4), pin persistente en sesión ✓ (Task 1), interacciones (click/Tab/Enter/doble click/Esc) ✓ (Task 4/5), decisión resize PTY ✓ (Task 2, `canResizePty`), paginación 12 ✓ (Task 4), replay 200 líneas ✓ (Task 2), badge ended ✓ (Task 3), estado vacío ✓ (Task 3), testing manual + build ✓ (Task 6). Suscripción única con fan-out del spec se simplificó a N suscripciones al `Set` del bus (mismo costo real, menos plumbing) — anotado como desvío consciente.
+2. **Placeholders:** ninguno; todos los pasos tienen código o comandos concretos.
+3. **Consistencia de tipos:** `HubEntry`/`HubFilter`/`filterEntries` definidos en Task 3 y consumidos idénticos en Task 4; `useHubTerminal(paneId, canResizePty)` idéntico entre Task 2 y 3; `onJump(tabId, paneId)`/`onTogglePin(tabId, paneId)` uniformes en Tasks 3/4/5.

--- a/docs/superpowers/plans/2026-07-14-hub-overlay.md
+++ b/docs/superpowers/plans/2026-07-14-hub-overlay.md
@@ -1089,3 +1089,389 @@ Reportar URL del PR draft. Recordar: review de Gero; pedir smoke en Mac/Linux en
 1. **Cobertura del spec:** entrada por atajo/palette/botón ✓ (Task 5), tiles con lenguaje visual + chip ✓ (Task 3/4), filtros + persistencia localStorage ✓ (Task 4), pin persistente en sesión ✓ (Task 1), interacciones (click/Tab/Enter/doble click/Esc) ✓ (Task 4/5), decisión resize PTY ✓ (Task 2, `canResizePty`), paginación 12 ✓ (Task 4), replay 200 líneas ✓ (Task 2), badge ended ✓ (Task 3), estado vacío ✓ (Task 3), testing manual + build ✓ (Task 6). Suscripción única con fan-out del spec se simplificó a N suscripciones al `Set` del bus (mismo costo real, menos plumbing) — anotado como desvío consciente.
 2. **Placeholders:** ninguno; todos los pasos tienen código o comandos concretos.
 3. **Consistencia de tipos:** `HubEntry`/`HubFilter`/`filterEntries` definidos en Task 3 y consumidos idénticos en Task 4; `useHubTerminal(paneId, canResizePty)` idéntico entre Task 2 y 3; `onJump(tabId, paneId)`/`onTogglePin(tabId, paneId)` uniformes en Tasks 3/4/5.
+
+---
+
+## Adición (2026-07-14): Hub como workspace desde el `+` (mockup A)
+
+Tareas 7-8, sobre la misma rama. El overlay ya existe y está revisado. Estas tareas extraen su núcleo a `HubView` y agregan la variante "Hub como pestaña", creada desde el estado vacío de un workspace nuevo. Las Global Constraints de arriba siguen vigentes.
+
+### Task 7: Extraer `HubView` (núcleo compartido) de `HubOverlay`
+
+**Files:**
+- Create: `src/components/HubView.tsx`
+- Modify: `src/components/HubOverlay.tsx` (pasa a wrapper)
+- Modify: `src/styles/global.css` (agregar `.hub-view`)
+
+**Interfaces:**
+- Produces (consumido por Task 8 y por HubOverlay): `<HubView tabs activeTabId activePanes onJump onTogglePin />` — el núcleo: estado de filtro (localStorage `nest-hub-filter`), paginación (PAGE_SIZE 12), teclado (Tab/Shift+Tab/Enter), toolbar de filtros + `HubGrid`. Excluye tabs con `isHub`.
+
+- [ ] **Step 1: Crear `src/components/HubView.tsx`**
+
+```tsx
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { WorkspaceTab } from '../types'
+import HubGrid, { HubEntry, HubFilter, filterEntries } from './HubGrid'
+
+const PAGE_SIZE = 12
+const FILTER_STORAGE_KEY = 'nest-hub-filter'
+
+function loadFilter(): HubFilter {
+  const raw = localStorage.getItem(FILTER_STORAGE_KEY)
+  if (raw === 'active' || raw === 'pinned') return raw
+  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
+  return 'all'
+}
+function saveFilter(f: HubFilter) {
+  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+}
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  activePanes: Set<string>
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogglePin }: Props) {
+  const [filter, setFilter] = useState<HubFilter>(loadFilter)
+  const [page, setPage] = useState(0)
+  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
+
+  // Hub tabs own no terminals; exclude them so they don't appear as empty
+  // per-workspace filter chips or contribute phantom entries.
+  const sourceTabs = useMemo(() => tabs.filter(t => !t.isHub), [tabs])
+
+  const entries = useMemo<HubEntry[]>(() =>
+    sourceTabs.flatMap(t =>
+      t.panes
+        .filter(p => p.aiType !== 'browser')
+        .map(p => ({
+          pane: p,
+          tabId: t.id,
+          tabName: t.name,
+          isActiveTab: t.id === activeTabId,
+          busy: activePanes.has(p.id),
+        }))
+    ), [sourceTabs, activeTabId, activePanes])
+
+  const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const visible = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const changeFilter = useCallback((f: HubFilter) => {
+    setFilter(f); setPage(0); saveFilter(f)
+  }, [])
+
+  useEffect(() => {
+    if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
+      setFocusedPaneId(null)
+    }
+  }, [visible, focusedPaneId])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        if (visible.length === 0) return
+        const idx = visible.findIndex(en => en.pane.id === focusedPaneId)
+        const next = e.shiftKey
+          ? (idx - 1 + visible.length) % visible.length
+          : (idx + 1) % visible.length
+        setFocusedPaneId(visible[next].pane.id)
+        return
+      }
+      if (e.key === 'Enter' && focusedPaneId) {
+        const entry = visible.find(en => en.pane.id === focusedPaneId)
+        if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
+          e.preventDefault()
+          onJump(entry.tabId, entry.pane.id)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [visible, focusedPaneId, onJump])
+
+  const counts = useMemo(() => ({
+    all: entries.length,
+    active: entries.filter(e => e.busy).length,
+    pinned: entries.filter(e => e.pane.pinned).length,
+  }), [entries])
+
+  const filterIs = (f: HubFilter) =>
+    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
+
+  return (
+    <div className="hub-view">
+      <div className="hub-toolbar">
+        <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
+          Todas <span className="hub-chip-n">{counts.all}</span>
+        </button>
+        <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
+          Activas <span className="hub-chip-n">{counts.active}</span>
+        </button>
+        <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
+          Pineadas <span className="hub-chip-n">{counts.pinned}</span>
+        </button>
+        <span className="hub-toolbar-sep" />
+        {sourceTabs.map(t => (
+          <button
+            key={t.id}
+            className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
+            onClick={() => changeFilter({ tabId: t.id })}
+          >
+            {t.name}
+          </button>
+        ))}
+        {pageCount > 1 && (
+          <span className="hub-pager">
+            <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
+            <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
+            <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
+          </span>
+        )}
+      </div>
+      <HubGrid
+        entries={visible}
+        focusedPaneId={focusedPaneId}
+        onFocus={setFocusedPaneId}
+        onJump={onJump}
+        onTogglePin={onTogglePin}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Reescribir `src/components/HubOverlay.tsx` como wrapper**
+
+```tsx
+import { WorkspaceTab } from '../types'
+import HubView from './HubView'
+import { formatBinding } from '../lib/keybindings'
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  activePanes: Set<string>
+  onClose: () => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubOverlay({ tabs, activeTabId, activePanes, onClose, onJump, onTogglePin }: Props) {
+  return (
+    <div className="hub-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="hub-panel">
+        <div className="hub-title">
+          <span>Hub — terminales activas</span>
+          <span className="hub-title-hint">
+            Esc volver · Tab siguiente · Enter ir al workspace · {formatBinding('Meta+Shift+O')} toggle
+          </span>
+        </div>
+        <HubView
+          tabs={tabs}
+          activeTabId={activeTabId}
+          activePanes={activePanes}
+          onJump={onJump}
+          onTogglePin={onTogglePin}
+        />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: CSS** — al final de `src/styles/global.css`:
+
+```css
+.hub-view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+```
+
+- [ ] **Step 4:** `npm run build` limpio. El overlay debe comportarse idéntico.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/HubView.tsx src/components/HubOverlay.tsx src/styles/global.css
+git commit -m "refactor(hub): extraer HubView del overlay para reusar como workspace
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Hub como workspace (`isHub`) creado desde el estado vacío
+
+**Files:**
+- Modify: `src/types.ts` (`WorkspaceTab.isHub`, `SessionData.tabs[].isHub`)
+- Create: `src/components/HubWorkspace.tsx`
+- Modify: `src/App.tsx` (render switch, convert handler, hasAnyTerminal, EmptyState, persistencia)
+- Modify: `src/components/TabBar.tsx` (ícono ▦)
+- Modify: `src/styles/global.css` (`.hub-workspace`, `.tab-hub-icon`, `.empty-hub-btn`)
+
+**Interfaces:**
+- Consumes: `HubView` (Task 7); `handleHubJump`/`handleHubTogglePin`/`activePanes`/`updateActiveTab` (ya existen en App).
+
+- [ ] **Step 1: `src/types.ts`** — en `interface WorkspaceTab`, después de `splitRatios?: Record<string, number[]>`:
+
+```ts
+  splitRatios?: Record<string, number[]>
+  isHub?: boolean  // true = pestaña que muestra el Hub (todas las terminales), sin panes propios
+```
+
+y en `SessionData.tabs` (objeto del array), después de su `splitRatios?`:
+
+```ts
+    splitRatios?: Record<string, number[]>
+    isHub?: boolean
+```
+
+- [ ] **Step 2: Crear `src/components/HubWorkspace.tsx`**
+
+```tsx
+import { WorkspaceTab } from '../types'
+import HubView from './HubView'
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  activePanes: Set<string>
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubWorkspace(props: Props) {
+  return (
+    <div className="hub-workspace">
+      <HubView {...props} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: `src/App.tsx` — import + hasAnyTerminal + convertActiveTabToHub**
+
+Import junto a `import HubOverlay from './components/HubOverlay'`:
+```ts
+import HubWorkspace from './components/HubWorkspace'
+```
+
+Cerca de `hubHasRemoteActivity` (mismo patrón `useMemo`):
+```ts
+  const hasAnyTerminal = useMemo(
+    () => tabs.some(t => !t.isHub && t.panes.some(p => p.aiType !== 'browser')),
+    [tabs]
+  )
+```
+
+Después de `handleHubTogglePin`:
+```ts
+  const convertActiveTabToHub = useCallback(() => {
+    updateActiveTab(t => ({ ...t, isHub: true, name: 'Hub' }))
+  }, [updateActiveTab])
+```
+
+- [ ] **Step 4: `src/App.tsx` — render switch** (alrededor de la línea 1148). Reemplazá exactamente:
+```tsx
+        {isInitialState ? (
+          <EmptyState onNewPane={addNextPane} />
+        ) : (
+```
+por:
+```tsx
+        {activeTab.isHub ? (
+          <HubWorkspace
+            tabs={tabs}
+            activeTabId={activeTabId}
+            activePanes={activePanes}
+            onJump={handleHubJump}
+            onTogglePin={handleHubTogglePin}
+          />
+        ) : isInitialState ? (
+          <EmptyState
+            onNewPane={addNextPane}
+            onShowHub={hasAnyTerminal ? convertActiveTabToHub : undefined}
+          />
+        ) : (
+```
+El resto del bloque (`<>...PaneLayoutEngine...</>` y su cierre `)}`) queda igual.
+
+- [ ] **Step 5: `src/App.tsx` — EmptyState acepta `onShowHub`** (función ~línea 1398). Reemplazá la firma `function EmptyState({ onNewPane }: { onNewPane: () => void })` por `function EmptyState({ onNewPane, onShowHub }: { onNewPane: () => void; onShowHub?: () => void })`, y antes del `</div>` de cierre de `.empty-state` (después del `<p className="empty-hint">…</p>`) agregá:
+```tsx
+      {onShowHub && (
+        <button className="empty-hub-btn" onClick={onShowHub}>
+          ▦ Ver todas las terminales (Hub)
+        </button>
+      )}
+```
+
+- [ ] **Step 6: `src/App.tsx` — persistencia.** En el save mapping (dentro de `tabs.map(tab => ({ ... }))`, después de `splitRatios: tab.splitRatios,`):
+```ts
+          splitRatios: tab.splitRatios,
+          isHub: tab.isHub,
+```
+y en `migrate` (rama v3 que retorna `layoutId`/`panes`/`splitRatios`), agregá `isHub: raw.isHub,` a ese objeto retornado.
+
+- [ ] **Step 7: `src/components/TabBar.tsx`** — en `SortableTab`, dentro del `<span className="tab-name" …>`, justo antes de `{tab.name}`:
+```tsx
+          {tab.isHub && <span className="tab-hub-icon">▦</span>}
+          {tab.name}
+```
+
+- [ ] **Step 8: CSS** — al final de `src/styles/global.css`:
+```css
+.hub-workspace {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-hub-icon {
+  color: var(--raven-blue);
+  margin-right: 5px;
+  font-size: 11px;
+}
+
+.empty-hub-btn {
+  margin-top: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 1px solid var(--raven-blue);
+  color: var(--raven-blue);
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.empty-hub-btn:hover {
+  background: #0066FF18;
+}
+```
+
+- [ ] **Step 9:** `npm run build` limpio.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/types.ts src/components/HubWorkspace.tsx src/App.tsx src/components/TabBar.tsx src/styles/global.css
+git commit -m "feat(hub): crear el Hub como workspace desde el estado vacío del +
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+**Verificación (test path manual):** + → tab vacío → "Ver todas las terminales (Hub)" convierte el tab (nombre Hub, ícono ▦, grilla con las terminales de los otros workspaces); escribir en un tile va a esa terminal; doble click salta al workspace (el tab Hub queda); el overlay `Ctrl+Shift+O` sigue igual; el botón del EmptyState no aparece si no hay terminales en otro workspace; cerrar/reabrir conserva el tab Hub.

--- a/docs/superpowers/specs/2026-07-14-hub-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-14-hub-overlay-design.md
@@ -46,9 +46,17 @@ Mismo lenguaje visual del pane actual (borde `color-mix` con `--pane-color`, hea
 
 Con más de 12 tiles tras filtrar: paginación simple (12 por página), para acotar la cantidad de xterms vivos.
 
+## Adición aprobada (2026-07-14): Hub como workspace desde el `+`
+
+Además del overlay, el Hub se puede crear como **una pestaña más**. Interacción elegida (mockup "A"): el `+` crea un workspace vacío como hoy (un click, sin cambios); en su **estado vacío** (`EmptyState`), junto a "+ New Terminal", aparece **"▦ Ver todas las terminales (Hub)"**. Al tocarlo, ese tab se convierte en la vista Hub (nombre → "Hub", ícono ▦ en la pestaña) y su contenido es la grilla de todas las terminales de los demás workspaces. El overlay (`Ctrl/Cmd+Shift+O`) se mantiene igual; ambos comparten el mismo núcleo `HubView`.
+
+- La grilla del overlay se refactoriza a `HubView` (toolbar de filtros + paginación + teclado + `HubGrid`). `HubOverlay` pasa a ser un wrapper (backdrop + título + `HubView`); `HubWorkspace` monta `HubView` inline como contenido del tab activo.
+- Un tab Hub tiene `isHub: true` y `panes: []`; se excluye de las fuentes/chips de filtro. Cuando es el tab activo, los demás tabs quedan inactivos → sus `TerminalPane` reales desmontados → los tiles del Hub son la única vista de esos PTYs (sin doble-vista, más limpio que el overlay).
+- `isHub` persiste en la sesión (save/restore/migrate). El botón del `EmptyState` solo aparece si hay terminales en algún otro workspace.
+- Limitación conocida (v1): si restaurás la sesión con el tab Hub activo, los PTYs de los otros tabs aún no existen (se crean al montar sus `TerminalPane`), así que esos tiles se ven vacíos/ended hasta visitar esos tabs una vez. Se documenta en el PR.
+
 ## Fuera de alcance (v1)
 
-- Workspace fijo "Hub" (variante A) — la arquitectura lo permite, no se construye ahora.
 - Panel lateral persistente (variante C).
 - Detección fina de "esperando input" (heurísticas de prompt): v1 usa las señales existentes (busy/actividad/idle/ended).
 - Broadcast cross-workspace desde el Hub.

--- a/docs/superpowers/specs/2026-07-14-hub-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-14-hub-overlay-design.md
@@ -1,0 +1,118 @@
+# Hub — vista compacta de terminales cross-workspace (overlay)
+
+**Fecha:** 2026-07-14
+**Estado:** propuesta — se implementa en `feat/hub-overlay` y queda como PR para review del equipo. No se mergea sin OK explícito.
+**Autor:** Matías (diseño asistido)
+
+## Problema
+
+Cada workspace (tab) muestra solo sus propios panes. Con agentes corriendo en 2–3 workspaces a la vez, no hay forma de ver qué está pasando en los demás ni de responder un prompt de otro workspace sin cambiar de tab a ciegas y volver. El único indicio actual es el punto verde de actividad en la pestaña (`.tab-activity-dot`), que no dice qué pane ni qué necesita.
+
+## Solución (v1)
+
+Un overlay **"Hub"** que se abre con `Ctrl+Shift+O` (`Cmd+Shift+O` en Mac) por encima del workspace actual y muestra en grilla todas las terminales vivas de todos los workspaces. Es **interactivo**: lo que se tipea va a la terminal enfocada. `Esc` cierra y devuelve el foco exactamente al pane previo.
+
+Mockups aprobados: variante B (overlay) de la comparativa A/B/C. La grilla se construye como componente independiente del contenedor para poder promoverla más adelante a un workspace fijo "Hub" (variante A) sin rehacer nada.
+
+### Puntos de entrada
+
+1. Atajo global `Ctrl/Cmd+Shift+O` (toggle).
+2. Entrada "Hub: ver todas las terminales" en la Command Palette.
+3. Botón en la tab bar (a la derecha del `+`), con punto de actividad cuando algún pane de un workspace no visible tiene actividad.
+
+### Qué muestra cada tile
+
+Mismo lenguaje visual del pane actual (borde `color-mix` con `--pane-color`, header teñido, punto de color, label del AI en mayúsculas, cuenta) más:
+
+- **Chip del workspace de origen** (estilo `.pane-pid-chip`, azul) con el nombre del tab.
+- Label de actividad existente (`.pane-activity-label`) / badge `ended` si el proceso murió.
+- Botón de **pin** en el header del tile.
+- Contenido: xterm real conectado al PTY existente (replay de las últimas ~200 líneas del buffer + stream en vivo).
+
+### Filtros (fila superior del overlay)
+
+`Todas` (default) · `Activas` (busy o con actividad reciente) · `Pineadas` · chips por workspace. El último filtro elegido se recuerda en `localStorage` (no amerita tocar el formato de sesión). Contadores por filtro.
+
+### Interacciones
+
+| Gesto | Acción |
+|---|---|
+| Click en tile | Foco: el teclado va a esa terminal |
+| `Tab` / `Shift+Tab` | Ciclar foco entre tiles |
+| Doble click o `Enter` sobre tile enfocado | Saltar a ese pane en su workspace (cierra overlay, activa el tab, enfoca el pane) |
+| `Esc` | Cerrar overlay y devolver foco al pane previo |
+| Pin en header | Alterna `pinned` del pane |
+| `Ctrl/Cmd+Shift+O` | Toggle abrir/cerrar |
+
+Con más de 12 tiles tras filtrar: paginación simple (12 por página), para acotar la cantidad de xterms vivos.
+
+## Fuera de alcance (v1)
+
+- Workspace fijo "Hub" (variante A) — la arquitectura lo permite, no se construye ahora.
+- Panel lateral persistente (variante C).
+- Detección fina de "esperando input" (heurísticas de prompt): v1 usa las señales existentes (busy/actividad/idle/ended).
+- Broadcast cross-workspace desde el Hub.
+- Reordenar/mover panes desde el Hub.
+
+## Arquitectura
+
+Sin IPC nuevo y sin store nuevo. Todas las piezas existen:
+
+- **PTYs**: viven en el main process para todos los workspaces (`electron/pty-manager.ts`, `Map<paneId, IPty>` + buffer de 10k líneas). `window.pty.write(paneId, …)` ya es global.
+- **Datos**: `tabs.flatMap(t => t.panes)` en `App.tsx` (fuente única de verdad; el overlay no copia estado).
+- **Stream**: `subscribeToPtyData` (`src/pty-events.ts`) entrega `(paneId, data)` de todas las terminales con un solo listener.
+- **Estado de actividad**: `busyPanes` y `tabActivity` existentes en `App.tsx`.
+
+### Componentes nuevos (`src/components/`)
+
+1. **`HubOverlay.tsx`** — contenedor overlay. Se monta en `App` gated por `hubOpen` (useState en App), mismo patrón que Command Palette / GlobalSearch. Maneja: atajo, `Esc`, prioridad frente a otros overlays (si palette o búsqueda están abiertos, `Esc` cierra esos primero; el atajo del Hub no abre si hay un dialog modal), guardar/restaurar el pane enfocado previo (`terminal-registry`), paginación y fila de filtros.
+2. **`HubGrid.tsx`** — grilla pura y reutilizable. Props: `entries: HubEntry[]` (`{ pane, tabId, tabName, tabColor, busy, ended }`), `focusedPaneId`, callbacks (`onFocus`, `onJump`, `onTogglePin`). Sin conocimiento del contenedor ni de App. Es la pieza que luego se monta en un tab Hub.
+3. **`HubTile.tsx`** — mini-pane. Header reutilizando clases/estilos de pane existentes + chip de workspace + pin. Cuerpo: instancia xterm propia (readonly hasta tener foco) conectada por `paneId`:
+   - mount → `window.pty.getBuffer(paneId)` (recortado a ~200 líneas) → `write()` → suscripción al stream global filtrando su `paneId`;
+   - unmount → `term.dispose()`; **nunca** matar el PTY (mismo contrato que `TerminalPane`).
+
+### Cambios en código existente
+
+- `App.tsx`: estado `hubOpen`, montaje de `HubOverlay`, entrada en Command Palette, botón en tab bar, handler de "jump" (setActiveTabId + foco de pane). Derivar `HubEntry[]` con `useMemo` sobre `tabs`/`busyPanes`/`tabActivity`.
+- `src/types.ts`: `pinned?: boolean` en `PaneNode` y `SessionPane` (persiste con el save/restore de sesión existente; migración trivial: ausente = false).
+- `src/styles/global.css`: sección nueva `/* ── Hub Overlay ── */` reutilizando tokens (`--raven-blue`, `--pane-color`, etc.). Sin colores hardcodeados nuevos.
+
+## Decisión técnica clave: tamaño del PTY
+
+Un PTY tiene un único cols×rows; hay dos vistas posibles del mismo PTY (pane real + tile del Hub).
+
+**Decisión:** solo el **tile enfocado** redimensiona el PTY a su tamaño (para poder interactuar con TUIs coherentemente). Los tiles sin foco renderizan el buffer sin resize — puede haber wrapping imperfecto, aceptable en una vista compacta. Al cerrar el overlay se re-ajustan (`fit()`) los panes montados del workspace activo, que es lo que ya pasa en un remount. Es el trade-off estándar de tmux con múltiples clientes.
+
+Riesgo residual: un agente TUI en el workspace activo visible detrás del overlay se redibuja chico si su tile toma foco. Mitigación: si el pane pertenece al workspace activo, el foco en su tile **no** redimensiona (ya está montado a tamaño real; solo se enruta el input).
+
+## Performance
+
+- xterm solo para los tiles de la página visible (máx. 12); `dispose()` al paginar/filtrar/cerrar.
+- Replay acotado a ~200 líneas por tile.
+- Suscripción única al bus de datos en `HubOverlay`, fan-out interno a los tiles (no 12 listeners IPC).
+- Overlay cerrado = costo cero (no se monta).
+
+## Errores y bordes
+
+- **PTY muerto**: tile con badge `ended` existente; para relanzar se salta al pane (el restart vive ahí).
+- **Cierre de pane/workspace con el Hub abierto**: la grilla se deriva de `tabs` en cada render; el tile desaparece solo. Si era el enfocado, el foco pasa al siguiente.
+- **Workspace activo dentro del Hub**: sus panes también aparecen (con su chip), para que la vista sea completa y predecible.
+- **0 resultados tras filtrar**: estado vacío con hint del filtro activo.
+
+## Testing (según CONTRIBUTING: ejercitar en la app real)
+
+- `npm run build` limpio (TS strict).
+- Manual (documentado en el PR): 3 workspaces con agentes → abrir Hub → tipear en terminal de otro workspace → verificar llegada; Enter salta al pane correcto; Esc devuelve foco; pin + filtro Pineadas; pane ended muestra badge; sesión con `pinned` sobrevive restart.
+- E2E Playwright (si el harness del repo lo permite sin fricción): abrir overlay, escribir cross-workspace, verificar eco en buffer.
+- Smoke en Windows (dev local) y pedir verificación Mac/Linux en el PR (requisito del equipo).
+
+## Checklist para el PR (controles del equipo)
+
+- [ ] PR enfocado: solo esta feature, sin "while I'm here".
+- [ ] Screenshots/recording del overlay en el body del PR (requisito CONTRIBUTING para UI).
+- [ ] El *why* en el body; el diff muestra el *what*.
+- [ ] Sin dependencias nuevas.
+- [ ] Tokens/estilos existentes, cero colores hardcodeados nuevos.
+- [ ] Review visual en app real antes de pedir review.
+- [ ] Nota de performance (xterms acotados, replay acotado) y de seguridad (sin IPC nuevo, sin superficie nueva).
+- [ ] **No se mergea**: queda para review y merge de Gero.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1074,13 +1074,8 @@ export default function App() {
     return out
   }, [tabs])
 
-  const hubHasRemoteActivity = useMemo(
-    () => tabs.some(t => t.id !== activeTabId && t.panes.some(p => activePanes.has(p.id))),
-    [tabs, activeTabId, activePanes]
-  )
-
-  const hasAnyTerminal = useMemo(
-    () => tabs.some(t => !t.isHub && t.panes.some(p => p.aiType !== 'browser')),
+  const hubTermCount = useMemo(
+    () => tabs.reduce((n, t) => t.isHub ? n : n + t.panes.filter(p => p.aiType !== 'browser').length, 0),
     [tabs]
   )
 
@@ -1097,15 +1092,7 @@ export default function App() {
         onTabColorChange={handleTabColorChange}
         isWin={window.platform?.isWin ?? false}
         tabActivity={tabActivity}
-        rightSlot={
-          <>
-            <button className="hub-btn" onClick={openHub} title={`Hub (${formatBinding('Meta+Shift+O')})`}>
-              Hub
-              {hubHasRemoteActivity && <span className="tab-activity-dot" />}
-            </button>
-            <ResourceBar panes={activePanesPayload} />
-          </>
-        }
+        rightSlot={<ResourceBar panes={activePanesPayload} />}
       />
       {updateStatus?.type === 'downloading' && (
         <div className="update-banner update-banner--downloading">
@@ -1207,7 +1194,8 @@ export default function App() {
         ) : isInitialState ? (
           <EmptyState
             onNewPane={addNextPane}
-            onShowHub={hasAnyTerminal ? convertActiveTabToHub : undefined}
+            onShowHub={hubTermCount > 0 ? convertActiveTabToHub : undefined}
+            hubCount={hubTermCount}
           />
         ) : (
           <>
@@ -1457,7 +1445,7 @@ function EmptyCell({ onClick }: { onClick: () => void }) {
   )
 }
 
-function EmptyState({ onNewPane, onShowHub }: { onNewPane: () => void; onShowHub?: () => void }) {
+function EmptyState({ onNewPane, onShowHub, hubCount }: { onNewPane: () => void; onShowHub?: () => void; hubCount?: number }) {
   return (
     <div className="empty-state">
       <div className="empty-logo">
@@ -1470,9 +1458,17 @@ function EmptyState({ onNewPane, onShowHub }: { onNewPane: () => void; onShowHub
       </button>
       <p className="empty-hint">or press <kbd>{window.platform?.isWin ? 'Ctrl+T' : '⌘T'}</kbd></p>
       {onShowHub && (
-        <button className="empty-hub-btn" onClick={onShowHub}>
-          ▦ Ver todas las terminales (Hub)
-        </button>
+        <>
+          <div className="empty-or">o</div>
+          <button className="empty-hub-btn" onClick={onShowHub}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" />
+              <rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+            </svg>
+            Ver todas las terminales en el Hub
+            {hubCount ? <span className="empty-hub-count">{hubCount}</span> : null}
+          </button>
+        </>
       )}
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { QuickWorktreePalette } from './components/QuickWorktreePalette'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import GlobalSearch from './components/GlobalSearch'
 import CommandPalette from './components/CommandPalette'
+import HubOverlay from './components/HubOverlay'
 import { focusTerminal } from './terminal-registry'
 import logoUrl from './assets/logo.png'
 import { useProfile } from './hooks/useProfile'
@@ -36,7 +37,7 @@ import { useGitHub } from './hooks/useGitHub'
 import { usePendingInvitesCount } from './hooks/usePendingInvitesCount'
 import { useSpeechRecognition } from './hooks/useSpeechRecognition'
 import { useSettings } from './hooks/useSettings'
-import { matchesBinding } from './lib/keybindings'
+import { matchesBinding, formatBinding } from './lib/keybindings'
 import { WORKTREE_DRAG_MIME } from './lib/dragTypes'
 import { useUserPreferences } from './hooks/useUserPreferences'
 import SharedTerminalViewer from './components/SharedTerminalViewer'
@@ -100,6 +101,10 @@ export default function App() {
   const [convSidebarOpen, setConvSidebarOpen] = useState(false)
   const [globalSearchOpen, setGlobalSearchOpen] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
+  const [hubOpen, setHubOpen] = useState(false)
+  const hubOpenRef = useRef(false)
+  hubOpenRef.current = hubOpen
+  const hubPrevFocusRef = useRef<string | null>(null)
   const [sidebarExpanded, setSidebarExpanded] = useState(false)
   const [fontSize, setFontSize] = useState<number>(() => {
     const saved = localStorage.getItem('nest-font-size')
@@ -556,6 +561,34 @@ export default function App() {
     setActiveTabId(id)
   }, [])
 
+  const openHub = useCallback(() => {
+    hubPrevFocusRef.current = focusedPaneIdRef.current
+    setHubOpen(true)
+  }, [])
+
+  const closeHub = useCallback(() => {
+    setHubOpen(false)
+    const prev = hubPrevFocusRef.current
+    // Restore focus after the overlay unmounts and the pane below re-renders.
+    if (prev) setTimeout(() => focusTerminal(prev), 50)
+  }, [])
+
+  const handleHubJump = useCallback((tabId: string, paneId: string) => {
+    setHubOpen(false)
+    setActiveTabId(tabId)
+    setFocusedPaneId(paneId)
+    focusedPaneIdRef.current = paneId
+    // The pane's xterm mounts on tab switch; focus once it registered.
+    setTimeout(() => focusTerminal(paneId), 150)
+  }, [])
+
+  const handleHubTogglePin = useCallback((tabId: string, paneId: string) => {
+    setTabs(prev => prev.map(t => t.id !== tabId ? t : {
+      ...t,
+      panes: t.panes.map(p => p.id !== paneId ? p : { ...p, pinned: !p.pinned }),
+    }))
+  }, [])
+
   const tabsRef = useRef(tabs)
   tabsRef.current = tabs
   const activeTabIdRef = useRef(activeTabId)
@@ -849,6 +882,7 @@ export default function App() {
         return
       }
 
+      if (e.key === 'Escape' && hubOpenRef.current) { closeHub(); return }
       if (e.key === 'Escape' && zoomedPaneIdRef.current !== null) { handleUnzoom(); return }
 
       if (!e.metaKey && !e.ctrlKey) return
@@ -894,6 +928,12 @@ export default function App() {
 
       if (matchesBinding(e, kb.globalSearch)) { e.preventDefault(); setGlobalSearchOpen(true); return }
       if (matchesBinding(e, kb.commandPalette)) { e.preventDefault(); setCommandPaletteOpen(v => !v); return }
+      if (matchesBinding(e, kb.hubOverlay)) {
+        e.preventDefault()
+        if (hubOpenRef.current) closeHub()
+        else openHub()
+        return
+      }
 
       if (matchesBinding(e, kb.nextPane) || matchesBinding(e, kb.prevPane)) {
         e.preventDefault()
@@ -921,7 +961,7 @@ export default function App() {
     // means non-modified keystrokes still flow through to the terminal.
     window.addEventListener('keydown', handler, true)
     return () => window.removeEventListener('keydown', handler, true)
-  }, [addNextPane, toggleListening, cycleTab, handleUnzoom, handleZoom, planLimits.allowVoice])
+  }, [addNextPane, toggleListening, cycleTab, handleUnzoom, handleZoom, planLimits.allowVoice, openHub, closeHub])
 
   const isInitialState = panes.length === 0
 
@@ -974,6 +1014,11 @@ export default function App() {
     return out
   }, [tabs])
 
+  const hubHasRemoteActivity = useMemo(
+    () => tabs.some(t => t.id !== activeTabId && t.panes.some(p => busyPanes.has(p.id))),
+    [tabs, activeTabId, busyPanes]
+  )
+
   return (
     <div className="app" style={{ '--tab-accent': activeTab.accentColor ?? 'var(--raven-blue)' } as React.CSSProperties}>
       <TabBar
@@ -987,7 +1032,15 @@ export default function App() {
         onTabColorChange={handleTabColorChange}
         isWin={window.platform?.isWin ?? false}
         tabActivity={tabActivity}
-        rightSlot={<ResourceBar panes={activePanesPayload} />}
+        rightSlot={
+          <>
+            <button className="hub-btn" onClick={openHub} title={`Hub (${formatBinding('Meta+Shift+O')})`}>
+              Hub
+              {hubHasRemoteActivity && <span className="tab-activity-dot" />}
+            </button>
+            <ResourceBar panes={activePanesPayload} />
+          </>
+        }
       />
       {updateStatus?.type === 'downloading' && (
         <div className="update-banner update-banner--downloading">
@@ -1179,6 +1232,17 @@ export default function App() {
         <GlobalSearch onClose={() => setGlobalSearchOpen(false)} />
       )}
 
+      {hubOpen && (
+        <HubOverlay
+          tabs={tabs}
+          activeTabId={activeTabId}
+          busyPanes={busyPanes}
+          onClose={closeHub}
+          onJump={handleHubJump}
+          onTogglePin={handleHubTogglePin}
+        />
+      )}
+
       {commandPaletteOpen && (
         <CommandPalette
           onClose={() => setCommandPaletteOpen(false)}
@@ -1194,6 +1258,7 @@ export default function App() {
           onNewTab={handleTabNew}
           onNewPane={addNextPane}
           onBroadcastToggle={() => setBroadcastMode(v => !v)}
+          onHubOpen={openHub}
         />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { DiffViewerPanel } from './components/DiffViewerPanel'
 import GlobalSearch from './components/GlobalSearch'
 import CommandPalette from './components/CommandPalette'
 import HubOverlay from './components/HubOverlay'
+import { useHubActivity } from './hub-activity'
 import { focusTerminal } from './terminal-registry'
 import logoUrl from './assets/logo.png'
 import { useProfile } from './hooks/useProfile'
@@ -116,6 +117,7 @@ export default function App() {
 
   // Busy state: paneId -> boolean
   const [busyPanes, setBusyPanes] = useState<Set<string>>(new Set())
+  const activePanes = useHubActivity()
 
   const handleBusyChange = useCallback((paneId: string, busy: boolean) => {
     setBusyPanes(prev => {
@@ -887,6 +889,18 @@ export default function App() {
 
       if (!e.metaKey && !e.ctrlKey) return
 
+      // While the Hub overlay is open, its own listener owns the keyboard.
+      // Swallow every App-level Meta/Ctrl binding (pane cycling, Cmd+1-9, new
+      // pane, zoom, font size…) so a shell shortcut typed into a Hub tile
+      // (e.g. Ctrl+←/→ word-jump) can't redirect focus to a hidden pane
+      // behind the overlay. Only the Hub toggle still acts here (to close);
+      // Escape is handled above. Returning without preventDefault lets the
+      // keystroke reach the focused tile's terminal.
+      if (hubOpenRef.current) {
+        if (matchesBinding(e, kb.hubOverlay)) { e.preventDefault(); closeHub(); return }
+        return
+      }
+
       if (matchesBinding(e, kb.newPane)) { e.preventDefault(); addNextPane(); return }
 
       if (matchesBinding(e, kb.fontSizeUp)) {
@@ -1015,8 +1029,8 @@ export default function App() {
   }, [tabs])
 
   const hubHasRemoteActivity = useMemo(
-    () => tabs.some(t => t.id !== activeTabId && t.panes.some(p => busyPanes.has(p.id))),
-    [tabs, activeTabId, busyPanes]
+    () => tabs.some(t => t.id !== activeTabId && t.panes.some(p => activePanes.has(p.id))),
+    [tabs, activeTabId, activePanes]
   )
 
   return (
@@ -1236,7 +1250,7 @@ export default function App() {
         <HubOverlay
           tabs={tabs}
           activeTabId={activeTabId}
-          busyPanes={busyPanes}
+          activePanes={activePanes}
           onClose={closeHub}
           onJump={handleHubJump}
           onTogglePin={handleHubTogglePin}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1380,6 +1380,7 @@ export default function App() {
                         onPtyStarted={handlePtyStarted}
                         allowSharing={planLimits.allowSharing}
                         onRequireUpgrade={() => setShowUpgrade(true)}
+                        onTogglePin={() => updatePaneAnywhere(pane.id, p => ({ ...p, pinned: !p.pinned }))}
                       />
                     )
                   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import GlobalSearch from './components/GlobalSearch'
 import CommandPalette from './components/CommandPalette'
 import HubOverlay from './components/HubOverlay'
 import HubWorkspace from './components/HubWorkspace'
+import { filterEntries, type HubFilter, type HubEntry } from './components/HubGrid'
 import { useHubActivity } from './hub-activity'
 import { focusTerminal } from './terminal-registry'
 import logoUrl from './assets/logo.png'
@@ -53,6 +54,17 @@ import { getTour } from './tutorial/registry'
 
 let paneCounter = 0
 const generateId = () => `pane-${++paneCounter}-${Date.now()}`
+
+const HUB_FILTER_KEY = 'nest-hub-filter'
+function loadHubFilter(): HubFilter {
+  const raw = localStorage.getItem(HUB_FILTER_KEY)
+  if (raw === 'active' || raw === 'pinned') return raw
+  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
+  return 'all'
+}
+function saveHubFilter(f: HubFilter): void {
+  localStorage.setItem(HUB_FILTER_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+}
 
 export default function App() {
   const generateTabId = () => `tab-${Date.now()}`
@@ -106,6 +118,9 @@ export default function App() {
   const [hubOpen, setHubOpen] = useState(false)
   const hubOpenRef = useRef(false)
   hubOpenRef.current = hubOpen
+  const [hubFilter, setHubFilter] = useState<HubFilter>(loadHubFilter)
+  const hubPanesRef = useRef<PaneNode[]>([])
+  const changeHubFilter = useCallback((f: HubFilter) => { setHubFilter(f); saveHubFilter(f) }, [])
   const hubPrevFocusRef = useRef<string | null>(null)
   const [sidebarExpanded, setSidebarExpanded] = useState(false)
   const [fontSize, setFontSize] = useState<number>(() => {
@@ -426,6 +441,43 @@ export default function App() {
       setFocusedPaneId(null)
     }
   }, [updateActiveTab, zoomedPaneId])
+
+  // ── Hub: los panes viven en OTROS workspaces, así que estos handlers operan
+  // sobre el tab de origen del pane (no sobre el tab activo, que es el Hub). ──
+  const updatePaneAnywhere = useCallback((paneId: string, updater: (p: PaneNode) => PaneNode) => {
+    setTabs(prev => prev.map(t =>
+      t.panes.some(p => p.id === paneId)
+        ? { ...t, panes: t.panes.map(p => p.id === paneId ? updater(p) : p) }
+        : t
+    ))
+  }, [])
+
+  const removePaneAnywhere = useCallback((paneId: string) => {
+    window.pty.kill(paneId)
+    setTabs(prev => prev.map(t => {
+      if (!t.panes.some(p => p.id === paneId)) return t
+      const nextPanes = t.panes.filter(p => p.id !== paneId)
+      const naturalDefault = defaultLayoutFor(nextPanes.length)
+      const demoted = getPreset(naturalDefault).slotCount < getPreset(t.layoutId).slotCount
+      return demoted
+        ? { ...t, panes: nextPanes, layoutId: naturalDefault, splitRatios: {} }
+        : { ...t, panes: nextPanes }
+    }))
+    if (zoomedPaneIdRef.current === paneId) { setZoomedPaneId(null); setZoomingOut(false) }
+    if (focusedPaneIdRef.current === paneId) { focusedPaneIdRef.current = null; setFocusedPaneId(null) }
+  }, [])
+
+  // Reordenar tiles del Hub: guarda el orden (ids) en el tab Hub activo.
+  const handleHubDragEnd = useCallback((e: DragEndEvent) => {
+    setDraggingId(null)
+    const { active, over } = e
+    if (!over || active.id === over.id) return
+    const ids = hubPanesRef.current.map(p => p.id)
+    const from = ids.indexOf(String(active.id))
+    const to = ids.indexOf(String(over.id))
+    if (from < 0 || to < 0) return
+    updateActiveTab(t => ({ ...t, hubOrder: swap(ids, from, to) }))
+  }, [updateActiveTab])
 
   const updatePaneColor = useCallback((paneId: string, borderColor: string) => {
     updateActiveTab(t => ({
@@ -1079,6 +1131,63 @@ export default function App() {
     [tabs]
   )
 
+  // Agregación de todas las terminales (de todos los workspaces) para el Hub:
+  // filtradas, ordenadas y capadas a MAX_PANES para el motor de layout.
+  const hubData = useMemo(() => {
+    if (!activeTab.isHub) return null
+    const source = tabs.filter(t => !t.isHub)
+    const entries: HubEntry[] = source.flatMap(t =>
+      t.panes.filter(p => p.aiType !== 'browser').map(p => ({
+        pane: p, tabId: t.id, tabName: t.name, isActiveTab: false, busy: activePanes.has(p.id),
+      })))
+    const counts = {
+      all: entries.length,
+      active: entries.filter(e => e.busy).length,
+      pinned: entries.filter(e => e.pane.pinned).length,
+    }
+    const order = activeTab.hubOrder ?? []
+    const ordered = [...filterEntries(entries, hubFilter)].sort((a, b) => {
+      const ia = order.indexOf(a.pane.id), ib = order.indexOf(b.pane.id)
+      if (ia === -1 && ib === -1) return 0
+      if (ia === -1) return 1
+      if (ib === -1) return -1
+      return ia - ib
+    })
+    const panes = ordered.slice(0, MAX_PANES).map(e => e.pane)
+    return {
+      panes,
+      layoutId: defaultLayoutFor(panes.length),
+      counts,
+      hiddenCount: Math.max(0, ordered.length - MAX_PANES),
+      sourceTabs: source.map(t => ({ id: t.id, name: t.name })),
+    }
+  }, [activeTab.isHub, activeTab.hubOrder, tabs, activePanes, hubFilter])
+  hubPanesRef.current = hubData?.panes ?? []
+
+  const renderHubPane = (pane: PaneNode) => (
+    <TerminalPane
+      key={pane.id}
+      pane={pane}
+      ports={panePorts[pane.id] ?? []}
+      isDragging={draggingId === pane.id}
+      zoomed={zoomedPaneId === pane.id}
+      zoomingOut={zoomedPaneId === pane.id && zoomingOut}
+      onZoom={() => handleZoom(pane.id)}
+      onClose={() => removePaneAnywhere(pane.id)}
+      onColorChange={(c) => updatePaneAnywhere(pane.id, p => ({ ...p, borderColor: c }))}
+      onNoteChange={(note) => updatePaneAnywhere(pane.id, p => ({ ...p, note }))}
+      fontSize={fontSize}
+      onInput={(data) => window.pty.write(pane.id, data)}
+      onFocus={() => { setFocusedPaneId(pane.id); focusedPaneIdRef.current = pane.id }}
+      onBusyChange={handleBusyChange}
+      onActivity={handlePaneActivity}
+      onJoinRequest={() => setJoinRequest({ paneId: pane.id, paneTitle: pane.customLabel ?? pane.accountName ?? 'Terminal' })}
+      onPtyStarted={(id, rp) => updatePaneAnywhere(id, p => ({ ...p, runningRepoPath: rp }))}
+      allowSharing={planLimits.allowSharing}
+      onRequireUpgrade={() => setShowUpgrade(true)}
+    />
+  )
+
   return (
     <div className="app" style={{ '--tab-accent': activeTab.accentColor ?? 'var(--raven-blue)' } as React.CSSProperties}>
       <TabBar
@@ -1185,11 +1294,20 @@ export default function App() {
       >
         {activeTab.isHub ? (
           <HubWorkspace
-            tabs={tabs}
-            activeTabId={activeTabId}
-            activePanes={activePanes}
-            onJump={handleHubJump}
-            onTogglePin={handleHubTogglePin}
+            panes={hubData?.panes ?? []}
+            layoutId={hubData?.layoutId ?? '1'}
+            splitRatios={activeTab.splitRatios}
+            sourceTabs={hubData?.sourceTabs ?? []}
+            filter={hubFilter}
+            counts={hubData?.counts ?? { all: 0, active: 0, pinned: 0 }}
+            hiddenCount={hubData?.hiddenCount ?? 0}
+            onFilter={changeHubFilter}
+            onResize={handleSplitResize}
+            onDragStart={handleDragStart}
+            onDragEnd={handleHubDragEnd}
+            draggingId={draggingId}
+            sensors={sensors}
+            renderPane={renderHubPane}
           />
         ) : isInitialState ? (
           <EmptyState

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1185,6 +1185,7 @@ export default function App() {
       onPtyStarted={(id, rp) => updatePaneAnywhere(id, p => ({ ...p, runningRepoPath: rp }))}
       allowSharing={planLimits.allowSharing}
       onRequireUpgrade={() => setShowUpgrade(true)}
+      onTogglePin={() => updatePaneAnywhere(pane.id, p => ({ ...p, pinned: !p.pinned }))}
     />
   )
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,6 +258,22 @@ export default function App() {
       setShowUpgrade(true)
       return
     }
+    // A Hub tab owns no terminals of its own (HubView filters isHub tabs out
+    // of the grid). Pushing a pane onto it would create an invisible,
+    // unclosable pane, so route the new terminal into a fresh workspace.
+    const activeNow = tabsRef.current.find(t => t.id === activeTabIdRef.current)
+    if (activeNow?.isHub) {
+      const newTabId = generateTabId()
+      const pane: PaneNode = {
+        id: generateId(), aiType, accountName, accountDir, borderColor, cmd,
+        customLabel, customColor, shellId,
+        repoPath: addingPaneRef.current?.worktreePath,
+      }
+      setTabs(prev => [...prev, { id: newTabId, name: 'Workspace', layoutId: '1', panes: [pane] }])
+      setActiveTabId(newTabId)
+      setAddingPane(null)
+      return
+    }
     const worktreePath = addingPaneRef.current?.worktreePath
     updateActiveTab(t => {
       const pane: PaneNode = {
@@ -679,6 +695,20 @@ export default function App() {
     if (panesRef.current.length >= MAX_PANES) return
     if (panesRef.current.length >= planLimits.maxPanes) {
       setShowUpgrade(true)
+      return
+    }
+    // Hub tabs own no panes — open the browser cell in a fresh workspace
+    // rather than pushing an invisible pane onto the Hub tab (see addPane).
+    const activeNow = tabsRef.current.find(t => t.id === activeTabIdRef.current)
+    if (activeNow?.isHub) {
+      const newTabId = generateTabId()
+      const pane: PaneNode = {
+        id: generateId(), aiType: 'browser', accountName: 'browser', accountDir: '',
+        borderColor: '#0066FF', cmd: '', url,
+        sessionPartition: `persist:browser-${newTabId}`,
+      }
+      setTabs(prev => [...prev, { id: newTabId, name: 'Workspace', layoutId: '1', panes: [pane] }])
+      setActiveTabId(newTabId)
       return
     }
     const pane: PaneNode = {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,11 +59,10 @@ const HUB_FILTER_KEY = 'nest-hub-filter'
 function loadHubFilter(): HubFilter {
   const raw = localStorage.getItem(HUB_FILTER_KEY)
   if (raw === 'active' || raw === 'pinned') return raw
-  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
   return 'all'
 }
 function saveHubFilter(f: HubFilter): void {
-  localStorage.setItem(HUB_FILTER_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+  localStorage.setItem(HUB_FILTER_KEY, f)
 }
 
 export default function App() {
@@ -1159,7 +1158,6 @@ export default function App() {
       layoutId: defaultLayoutFor(panes.length),
       counts,
       hiddenCount: Math.max(0, ordered.length - MAX_PANES),
-      sourceTabs: source.map(t => ({ id: t.id, name: t.name })),
     }
   }, [activeTab.isHub, activeTab.hubOrder, tabs, activePanes, hubFilter])
   hubPanesRef.current = hubData?.panes ?? []
@@ -1298,7 +1296,6 @@ export default function App() {
             panes={hubData?.panes ?? []}
             layoutId={hubData?.layoutId ?? '1'}
             splitRatios={activeTab.splitRatios}
-            sourceTabs={hubData?.sourceTabs ?? []}
             filter={hubFilter}
             counts={hubData?.counts ?? { all: 0, active: 0, pinned: 0 }}
             hiddenCount={hubData?.hiddenCount ?? 0}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -384,6 +384,9 @@ export default function App() {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // The Hub overlay owns the keyboard while open — don't open worktree/diff
+      // modals behind it using the hidden workspace's context.
+      if (hubOpenRef.current) return
       const isCmdShift = (e.metaKey || e.ctrlKey) && e.shiftKey
       if (isCmdShift && e.key.toLowerCase() === 'w') {
         if (!activeTab.repoPath) return
@@ -581,9 +584,12 @@ export default function App() {
   }, [])
 
   const openHub = useCallback(() => {
+    // Already viewing the Hub as a workspace tab — don't stack the overlay on
+    // top (would mount a second HubView / duplicate xterms for the same PTYs).
+    if (activeTab.isHub) return
     hubPrevFocusRef.current = focusedPaneIdRef.current
     setHubOpen(true)
-  }, [])
+  }, [activeTab.isHub])
 
   const closeHub = useCallback(() => {
     setHubOpen(false)
@@ -609,7 +615,10 @@ export default function App() {
   }, [])
 
   const convertActiveTabToHub = useCallback(() => {
-    updateActiveTab(t => ({ ...t, isHub: true, name: 'Hub' }))
+    // A Hub tab owns no panes (HubView would filter them out → invisible,
+    // uncloseable). Only reached from EmptyState (panes already []), but clear
+    // defensively so a Hub tab can never hold orphan panes.
+    updateActiveTab(t => ({ ...t, isHub: true, name: 'Hub', panes: [] }))
   }, [updateActiveTab])
 
   const tabsRef = useRef(tabs)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -822,6 +822,7 @@ export default function App() {
             customLabel: p.customLabel, customColor: p.customColor, note: p.note,
             repoPath: p.repoPath,
             shellId: p.shellId,
+            pinned: p.pinned,
             // Persist the browser pane's current URL so reopening Nest (or
             // switching workspaces) restores the page instead of the placeholder.
             url: p.url,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { DiffViewerPanel } from './components/DiffViewerPanel'
 import GlobalSearch from './components/GlobalSearch'
 import CommandPalette from './components/CommandPalette'
 import HubOverlay from './components/HubOverlay'
+import HubWorkspace from './components/HubWorkspace'
 import { useHubActivity } from './hub-activity'
 import { focusTerminal } from './terminal-registry'
 import logoUrl from './assets/logo.png'
@@ -591,6 +592,10 @@ export default function App() {
     }))
   }, [])
 
+  const convertActiveTabToHub = useCallback(() => {
+    updateActiveTab(t => ({ ...t, isHub: true, name: 'Hub' }))
+  }, [updateActiveTab])
+
   const tabsRef = useRef(tabs)
   tabsRef.current = tabs
   const activeTabIdRef = useRef(activeTabId)
@@ -765,6 +770,7 @@ export default function App() {
             layoutId: raw.layoutId,
             panes: raw.panes.map(sessionToPane),
             splitRatios: raw.splitRatios ?? {},
+            isHub: raw.isHub,
           }
         }
         // v2: layout + cells
@@ -863,6 +869,7 @@ export default function App() {
             url: p.url,
           })),
           splitRatios: tab.splitRatios,
+          isHub: tab.isHub,
         })),
         activeTabId,
       }
@@ -1033,6 +1040,11 @@ export default function App() {
     [tabs, activeTabId, activePanes]
   )
 
+  const hasAnyTerminal = useMemo(
+    () => tabs.some(t => !t.isHub && t.panes.some(p => p.aiType !== 'browser')),
+    [tabs]
+  )
+
   return (
     <div className="app" style={{ '--tab-accent': activeTab.accentColor ?? 'var(--raven-blue)' } as React.CSSProperties}>
       <TabBar
@@ -1145,8 +1157,19 @@ export default function App() {
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        {isInitialState ? (
-          <EmptyState onNewPane={addNextPane} />
+        {activeTab.isHub ? (
+          <HubWorkspace
+            tabs={tabs}
+            activeTabId={activeTabId}
+            activePanes={activePanes}
+            onJump={handleHubJump}
+            onTogglePin={handleHubTogglePin}
+          />
+        ) : isInitialState ? (
+          <EmptyState
+            onNewPane={addNextPane}
+            onShowHub={hasAnyTerminal ? convertActiveTabToHub : undefined}
+          />
         ) : (
           <>
             {zoomedPaneId !== null && (
@@ -1395,7 +1418,7 @@ function EmptyCell({ onClick }: { onClick: () => void }) {
   )
 }
 
-function EmptyState({ onNewPane }: { onNewPane: () => void }) {
+function EmptyState({ onNewPane, onShowHub }: { onNewPane: () => void; onShowHub?: () => void }) {
   return (
     <div className="empty-state">
       <div className="empty-logo">
@@ -1407,6 +1430,11 @@ function EmptyState({ onNewPane }: { onNewPane: () => void }) {
         + New Terminal
       </button>
       <p className="empty-hint">or press <kbd>{window.platform?.isWin ? 'Ctrl+T' : '⌘T'}</kbd></p>
+      {onShowHub && (
+        <button className="empty-hub-btn" onClick={onShowHub}>
+          ▦ Ver todas las terminales (Hub)
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -24,6 +24,7 @@ interface Props {
   onNewTab: () => void
   onNewPane: () => void
   onBroadcastToggle: () => void
+  onHubOpen: () => void
 }
 
 function score(item: PaletteItem, query: string): number {
@@ -57,7 +58,7 @@ const SECTION_LABELS: Record<PaletteItem['section'], string> = {
 export default function CommandPalette({
   onClose, tabs, activeTabId, focusedPaneId, broadcastMode,
   onTabSelect, onWorkspaceLoad, onSnippetSend, onSnippetBroadcast,
-  onHistoryOpen, onNewTab, onNewPane, onBroadcastToggle,
+  onHistoryOpen, onNewTab, onNewPane, onBroadcastToggle, onHubOpen,
 }: Props) {
   const [query, setQuery] = useState('')
   const [selectedIdx, setSelectedIdx] = useState(0)
@@ -102,6 +103,13 @@ export default function CommandPalette({
       sublabel: broadcastMode ? 'Stop sending to all terminals' : 'Send to all terminals',
       keywords: 'broadcast all terminals',
       action: () => { onBroadcastToggle(); onClose() },
+    })
+    items.push({
+      id: 'action-hub', section: 'actions',
+      label: 'Hub: ver todas las terminales',
+      sublabel: 'Vista compacta de todos los workspaces',
+      keywords: 'hub overview terminales workspaces todas',
+      action: () => { onHubOpen(); onClose() },
     })
     items.push({
       id: 'action-history', section: 'actions',
@@ -163,7 +171,7 @@ export default function CommandPalette({
 
     return items
   }, [tabs, activeTabId, workspaces, snippets, conversations, broadcastMode,
-      onNewTab, onNewPane, onBroadcastToggle, onHistoryOpen,
+      onNewTab, onNewPane, onBroadcastToggle, onHubOpen, onHistoryOpen,
       onTabSelect, onWorkspaceLoad, onSnippetSend, onSnippetBroadcast, onClose])
 
   const filtered = buildItems()

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -1,0 +1,47 @@
+import { PaneNode } from '../types'
+import HubTile from './HubTile'
+
+export interface HubEntry {
+  pane: PaneNode
+  tabId: string
+  tabName: string
+  isActiveTab: boolean
+  busy: boolean
+}
+
+export type HubFilter = 'all' | 'active' | 'pinned' | { tabId: string }
+
+export function filterEntries(entries: HubEntry[], filter: HubFilter): HubEntry[] {
+  if (filter === 'all') return entries
+  if (filter === 'active') return entries.filter(e => e.busy)
+  if (filter === 'pinned') return entries.filter(e => e.pane.pinned)
+  return entries.filter(e => e.tabId === filter.tabId)
+}
+
+interface Props {
+  entries: HubEntry[]
+  focusedPaneId: string | null
+  onFocus: (paneId: string) => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubGrid({ entries, focusedPaneId, onFocus, onJump, onTogglePin }: Props) {
+  if (entries.length === 0) {
+    return <div className="hub-empty">No hay terminales para este filtro</div>
+  }
+  return (
+    <div className="hub-grid">
+      {entries.map(e => (
+        <HubTile
+          key={e.pane.id}
+          entry={e}
+          focused={focusedPaneId === e.pane.id}
+          onFocus={onFocus}
+          onJump={onJump}
+          onTogglePin={onTogglePin}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/HubGrid.tsx
+++ b/src/components/HubGrid.tsx
@@ -9,13 +9,14 @@ export interface HubEntry {
   busy: boolean
 }
 
-export type HubFilter = 'all' | 'active' | 'pinned' | { tabId: string }
+// Filtros transversales del Hub. NO hay filtro por-workspace: filtrar a un solo
+// workspace mostraría lo mismo que ir a su pestaña, así que no aporta nada.
+export type HubFilter = 'all' | 'active' | 'pinned'
 
 export function filterEntries(entries: HubEntry[], filter: HubFilter): HubEntry[] {
-  if (filter === 'all') return entries
   if (filter === 'active') return entries.filter(e => e.busy)
   if (filter === 'pinned') return entries.filter(e => e.pane.pinned)
-  return entries.filter(e => e.tabId === filter.tabId)
+  return entries  // 'all'
 }
 
 interface Props {

--- a/src/components/HubOverlay.tsx
+++ b/src/components/HubOverlay.tsx
@@ -1,21 +1,6 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
 import { WorkspaceTab } from '../types'
-import HubGrid, { HubEntry, HubFilter, filterEntries } from './HubGrid'
+import HubView from './HubView'
 import { formatBinding } from '../lib/keybindings'
-
-const PAGE_SIZE = 12
-const FILTER_STORAGE_KEY = 'nest-hub-filter'
-
-function loadFilter(): HubFilter {
-  const raw = localStorage.getItem(FILTER_STORAGE_KEY)
-  if (raw === 'active' || raw === 'pinned') return raw
-  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
-  return 'all'
-}
-
-function saveFilter(f: HubFilter) {
-  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
-}
 
 interface Props {
   tabs: WorkspaceTab[]
@@ -27,80 +12,6 @@ interface Props {
 }
 
 export default function HubOverlay({ tabs, activeTabId, activePanes, onClose, onJump, onTogglePin }: Props) {
-  const [filter, setFilter] = useState<HubFilter>(loadFilter)
-  const [page, setPage] = useState(0)
-  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
-
-  const entries = useMemo<HubEntry[]>(() =>
-    tabs.flatMap(t =>
-      t.panes
-        .filter(p => p.aiType !== 'browser')
-        .map(p => ({
-          pane: p,
-          tabId: t.id,
-          tabName: t.name,
-          isActiveTab: t.id === activeTabId,
-          busy: activePanes.has(p.id),
-        }))
-    ), [tabs, activeTabId, activePanes])
-
-  const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
-  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
-  const clampedPage = Math.min(page, pageCount - 1)
-  const visible = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
-
-  const changeFilter = useCallback((f: HubFilter) => {
-    setFilter(f)
-    setPage(0)
-    saveFilter(f)
-  }, [])
-
-  // If the focused pane left the visible set (filter change, pane closed),
-  // drop focus so Tab cycling restarts from the first tile.
-  useEffect(() => {
-    if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
-      setFocusedPaneId(null)
-    }
-  }, [visible, focusedPaneId])
-
-  // Keyboard: Tab cycles tiles; Enter jumps to the focused pane's workspace.
-  // Escape is handled centrally in App.tsx (capture phase) so overlay
-  // priority lives in one place.
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        e.preventDefault()
-        if (visible.length === 0) return
-        const idx = visible.findIndex(en => en.pane.id === focusedPaneId)
-        const next = e.shiftKey
-          ? (idx - 1 + visible.length) % visible.length
-          : (idx + 1) % visible.length
-        setFocusedPaneId(visible[next].pane.id)
-        return
-      }
-      if (e.key === 'Enter' && focusedPaneId) {
-        const entry = visible.find(en => en.pane.id === focusedPaneId)
-        // Only when the xterm itself isn't consuming Enter (i.e. the tile is
-        // focused via Tab but the user hasn't clicked into the terminal).
-        if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
-          e.preventDefault()
-          onJump(entry.tabId, entry.pane.id)
-        }
-      }
-    }
-    window.addEventListener('keydown', handler, true)
-    return () => window.removeEventListener('keydown', handler, true)
-  }, [visible, focusedPaneId, onJump])
-
-  const counts = useMemo(() => ({
-    all: entries.length,
-    active: entries.filter(e => e.busy).length,
-    pinned: entries.filter(e => e.pane.pinned).length,
-  }), [entries])
-
-  const filterIs = (f: HubFilter) =>
-    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
-
   return (
     <div className="hub-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
       <div className="hub-panel">
@@ -110,38 +21,10 @@ export default function HubOverlay({ tabs, activeTabId, activePanes, onClose, on
             Esc volver · Tab siguiente · Enter ir al workspace · {formatBinding('Meta+Shift+O')} toggle
           </span>
         </div>
-        <div className="hub-toolbar">
-          <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
-            Todas <span className="hub-chip-n">{counts.all}</span>
-          </button>
-          <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
-            Activas <span className="hub-chip-n">{counts.active}</span>
-          </button>
-          <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
-            Pineadas <span className="hub-chip-n">{counts.pinned}</span>
-          </button>
-          <span className="hub-toolbar-sep" />
-          {tabs.map(t => (
-            <button
-              key={t.id}
-              className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
-              onClick={() => changeFilter({ tabId: t.id })}
-            >
-              {t.name}
-            </button>
-          ))}
-          {pageCount > 1 && (
-            <span className="hub-pager">
-              <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
-              <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
-              <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
-            </span>
-          )}
-        </div>
-        <HubGrid
-          entries={visible}
-          focusedPaneId={focusedPaneId}
-          onFocus={setFocusedPaneId}
+        <HubView
+          tabs={tabs}
+          activeTabId={activeTabId}
+          activePanes={activePanes}
           onJump={onJump}
           onTogglePin={onTogglePin}
         />

--- a/src/components/HubOverlay.tsx
+++ b/src/components/HubOverlay.tsx
@@ -16,7 +16,7 @@ export default function HubOverlay({ tabs, activeTabId, activePanes, onClose, on
     <div className="hub-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
       <div className="hub-panel">
         <div className="hub-title">
-          <span>Hub — terminales activas</span>
+          <span>Hub — todas tus terminales</span>
           <span className="hub-title-hint">
             Esc volver · Tab siguiente · Enter ir al workspace · {formatBinding('Meta+Shift+O')} toggle
           </span>

--- a/src/components/HubOverlay.tsx
+++ b/src/components/HubOverlay.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { WorkspaceTab } from '../types'
+import HubGrid, { HubEntry, HubFilter, filterEntries } from './HubGrid'
+import { formatBinding } from '../lib/keybindings'
+
+const PAGE_SIZE = 12
+const FILTER_STORAGE_KEY = 'nest-hub-filter'
+
+function loadFilter(): HubFilter {
+  const raw = localStorage.getItem(FILTER_STORAGE_KEY)
+  if (raw === 'active' || raw === 'pinned') return raw
+  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
+  return 'all'
+}
+
+function saveFilter(f: HubFilter) {
+  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+}
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  busyPanes: Set<string>
+  onClose: () => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubOverlay({ tabs, activeTabId, busyPanes, onClose, onJump, onTogglePin }: Props) {
+  const [filter, setFilter] = useState<HubFilter>(loadFilter)
+  const [page, setPage] = useState(0)
+  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
+
+  const entries = useMemo<HubEntry[]>(() =>
+    tabs.flatMap(t =>
+      t.panes
+        .filter(p => p.aiType !== 'browser')
+        .map(p => ({
+          pane: p,
+          tabId: t.id,
+          tabName: t.name,
+          isActiveTab: t.id === activeTabId,
+          busy: busyPanes.has(p.id),
+        }))
+    ), [tabs, activeTabId, busyPanes])
+
+  const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const visible = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const changeFilter = useCallback((f: HubFilter) => {
+    setFilter(f)
+    setPage(0)
+    saveFilter(f)
+  }, [])
+
+  // If the focused pane left the visible set (filter change, pane closed),
+  // drop focus so Tab cycling restarts from the first tile.
+  useEffect(() => {
+    if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
+      setFocusedPaneId(null)
+    }
+  }, [visible, focusedPaneId])
+
+  // Keyboard: Tab cycles tiles; Enter jumps to the focused pane's workspace.
+  // Escape is handled centrally in App.tsx (capture phase) so overlay
+  // priority lives in one place.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        if (visible.length === 0) return
+        const idx = visible.findIndex(en => en.pane.id === focusedPaneId)
+        const next = e.shiftKey
+          ? (idx - 1 + visible.length) % visible.length
+          : (idx + 1) % visible.length
+        setFocusedPaneId(visible[next].pane.id)
+        return
+      }
+      if (e.key === 'Enter' && focusedPaneId) {
+        const entry = visible.find(en => en.pane.id === focusedPaneId)
+        // Only when the xterm itself isn't consuming Enter (i.e. the tile is
+        // focused via Tab but the user hasn't clicked into the terminal).
+        if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
+          e.preventDefault()
+          onJump(entry.tabId, entry.pane.id)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [visible, focusedPaneId, onJump])
+
+  const counts = useMemo(() => ({
+    all: entries.length,
+    active: entries.filter(e => e.busy).length,
+    pinned: entries.filter(e => e.pane.pinned).length,
+  }), [entries])
+
+  const filterIs = (f: HubFilter) =>
+    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
+
+  return (
+    <div className="hub-overlay" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="hub-panel">
+        <div className="hub-title">
+          <span>Hub — terminales activas</span>
+          <span className="hub-title-hint">
+            Esc volver · Tab siguiente · Enter ir al workspace · {formatBinding('Meta+Shift+O')} toggle
+          </span>
+        </div>
+        <div className="hub-toolbar">
+          <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
+            Todas <span className="hub-chip-n">{counts.all}</span>
+          </button>
+          <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
+            Activas <span className="hub-chip-n">{counts.active}</span>
+          </button>
+          <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
+            Pineadas <span className="hub-chip-n">{counts.pinned}</span>
+          </button>
+          <span className="hub-toolbar-sep" />
+          {tabs.map(t => (
+            <button
+              key={t.id}
+              className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
+              onClick={() => changeFilter({ tabId: t.id })}
+            >
+              {t.name}
+            </button>
+          ))}
+          {pageCount > 1 && (
+            <span className="hub-pager">
+              <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
+              <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
+              <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
+            </span>
+          )}
+        </div>
+        <HubGrid
+          entries={visible}
+          focusedPaneId={focusedPaneId}
+          onFocus={setFocusedPaneId}
+          onJump={onJump}
+          onTogglePin={onTogglePin}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/HubOverlay.tsx
+++ b/src/components/HubOverlay.tsx
@@ -20,13 +20,13 @@ function saveFilter(f: HubFilter) {
 interface Props {
   tabs: WorkspaceTab[]
   activeTabId: string
-  busyPanes: Set<string>
+  activePanes: Set<string>
   onClose: () => void
   onJump: (tabId: string, paneId: string) => void
   onTogglePin: (tabId: string, paneId: string) => void
 }
 
-export default function HubOverlay({ tabs, activeTabId, busyPanes, onClose, onJump, onTogglePin }: Props) {
+export default function HubOverlay({ tabs, activeTabId, activePanes, onClose, onJump, onTogglePin }: Props) {
   const [filter, setFilter] = useState<HubFilter>(loadFilter)
   const [page, setPage] = useState(0)
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
@@ -40,9 +40,9 @@ export default function HubOverlay({ tabs, activeTabId, busyPanes, onClose, onJu
           tabId: t.id,
           tabName: t.name,
           isActiveTab: t.id === activeTabId,
-          busy: busyPanes.has(p.id),
+          busy: activePanes.has(p.id),
         }))
-    ), [tabs, activeTabId, busyPanes])
+    ), [tabs, activeTabId, activePanes])
 
   const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
   const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))

--- a/src/components/HubTile.tsx
+++ b/src/components/HubTile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { AI_CONFIG } from '../types'
 import { useHubTerminal } from '../hooks/useHubTerminal'
+import { subscribeToPtyExit } from '../pty-events'
 import type { HubEntry } from './HubGrid'
 
 interface Props {
@@ -22,6 +23,11 @@ export default function HubTile({ entry, focused, onFocus, onJump, onTogglePin }
     let alive = true
     window.pty.exists(pane.id).then(exists => { if (alive) setEnded(!exists) })
     return () => { alive = false }
+  }, [pane.id])
+
+  // Live exit: flip to the ended badge if the PTY dies while this tile is open.
+  useEffect(() => {
+    return subscribeToPtyExit((id) => { if (id === pane.id) setEnded(true) })
   }, [pane.id])
 
   // External focus (Tab cycling from HubOverlay) → focus the xterm too

--- a/src/components/HubTile.tsx
+++ b/src/components/HubTile.tsx
@@ -30,11 +30,9 @@ export default function HubTile({ entry, focused, onFocus, onJump, onTogglePin }
     return subscribeToPtyExit((id) => { if (id === pane.id) setEnded(true) })
   }, [pane.id])
 
-  // External focus (Tab cycling from HubOverlay) → focus the xterm too
-  useEffect(() => {
-    if (focused) focusTile()
-  }, [focused, focusTile])
-
+  // Keyboard selection (Tab cycling) only moves the selection ring — it does
+  // NOT pull DOM focus into the xterm. That keeps Tab/Enter as Hub gestures
+  // (cycle / jump); typing into a tile is opt-in via click (see onMouseDown).
   const aiColor = pane.borderColor ?? pane.customColor ?? AI_CONFIG[pane.aiType]?.color ?? '#888888'
   const aiLabel = pane.customLabel ?? AI_CONFIG[pane.aiType].label
 

--- a/src/components/HubTile.tsx
+++ b/src/components/HubTile.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+import { AI_CONFIG } from '../types'
+import { useHubTerminal } from '../hooks/useHubTerminal'
+import type { HubEntry } from './HubGrid'
+
+interface Props {
+  entry: HubEntry
+  focused: boolean
+  onFocus: (paneId: string) => void
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubTile({ entry, focused, onFocus, onJump, onTogglePin }: Props) {
+  const { pane, tabId, tabName, isActiveTab, busy } = entry
+  // Active-tab panes stay mounted at real size behind the overlay — never
+  // resize their PTY from a tile (see spec: "tamaño del PTY").
+  const { containerRef, focusTile } = useHubTerminal(pane.id, !isActiveTab)
+  const [ended, setEnded] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    window.pty.exists(pane.id).then(exists => { if (alive) setEnded(!exists) })
+    return () => { alive = false }
+  }, [pane.id])
+
+  // External focus (Tab cycling from HubOverlay) → focus the xterm too
+  useEffect(() => {
+    if (focused) focusTile()
+  }, [focused, focusTile])
+
+  const aiColor = pane.borderColor ?? pane.customColor ?? AI_CONFIG[pane.aiType]?.color ?? '#888888'
+  const aiLabel = pane.customLabel ?? AI_CONFIG[pane.aiType].label
+
+  return (
+    <div
+      className={`hub-tile${focused ? ' focused' : ''}`}
+      style={{ '--pane-color': aiColor } as React.CSSProperties}
+      onMouseDown={() => { onFocus(pane.id); focusTile() }}
+      onDoubleClick={() => onJump(tabId, pane.id)}
+    >
+      <div className="hub-tile-header">
+        <span className="pane-color-btn" style={{ background: aiColor, cursor: 'default' }} />
+        <span className="pane-ai-label" style={{ color: aiColor }}>{aiLabel}</span>
+        {pane.accountName && !AI_CONFIG[pane.aiType]?.noAccount && (
+          <span className="pane-account-name">{pane.accountName}</span>
+        )}
+        <span className="hub-tile-ws" title={`Workspace: ${tabName}`}>{tabName}</span>
+        {busy && !ended && <span className="hub-tile-busy" />}
+        {ended && <span className="pane-ended-badge">ended</span>}
+        <span className="hub-tile-spacer" />
+        <button
+          className={`hub-tile-pin${pane.pinned ? ' pinned' : ''}`}
+          title={pane.pinned ? 'Quitar pin' : 'Pinear al Hub'}
+          onClick={(e) => { e.stopPropagation(); onTogglePin(tabId, pane.id) }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          pin
+        </button>
+      </div>
+      <div ref={containerRef} className="hub-tile-terminal" />
+    </div>
+  )
+}

--- a/src/components/HubTile.tsx
+++ b/src/components/HubTile.tsx
@@ -60,7 +60,15 @@ export default function HubTile({ entry, focused, onFocus, onJump, onTogglePin }
           onMouseDown={(e) => e.stopPropagation()}
           onDoubleClick={(e) => e.stopPropagation()}
         >
-          pin
+          {pane.pinned ? (
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M9 4v6l-2 3v2h10v-2l-2-3V4z" /><rect x="11" y="17" width="2" height="4" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M9 4v6l-2 3v2h10v-2l-2-3V4z" /><path d="M12 17v4" />
+            </svg>
+          )}
         </button>
       </div>
       <div ref={containerRef} className="hub-tile-terminal" />

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -127,9 +127,13 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
         ))}
         {pageCount > 1 && (
           <span className="hub-pager">
-            <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
+            <button className="hub-chip hub-pager-btn" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))} aria-label="Página anterior">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M15 18l-6-6 6-6" /></svg>
+            </button>
             <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
-            <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
+            <button className="hub-chip hub-pager-btn" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)} aria-label="Página siguiente">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M9 18l6-6-6-6" /></svg>
+            </button>
           </span>
         )}
       </div>

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -68,6 +68,9 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
+        // If the user clicked into a tile's terminal, Tab belongs to the shell
+        // (autocomplete) — don't hijack it for tile cycling.
+        if (document.activeElement?.closest('.hub-tile-terminal')) return
         e.preventDefault()
         if (visible.length === 0) return
         const idx = visible.findIndex(en => en.pane.id === focusedPaneId)

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -8,11 +8,10 @@ const FILTER_STORAGE_KEY = 'nest-hub-filter'
 function loadFilter(): HubFilter {
   const raw = localStorage.getItem(FILTER_STORAGE_KEY)
   if (raw === 'active' || raw === 'pinned') return raw
-  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
   return 'all'
 }
 function saveFilter(f: HubFilter) {
-  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+  localStorage.setItem(FILTER_STORAGE_KEY, f)
 }
 
 interface Props {
@@ -28,8 +27,7 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
   const [page, setPage] = useState(0)
   const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
 
-  // Hub tabs own no terminals; exclude them so they don't appear as empty
-  // per-workspace filter chips or contribute phantom entries.
+  // Hub tabs own no terminals; exclude them so they don't contribute phantom entries.
   const sourceTabs = useMemo(() => tabs.filter(t => !t.isHub), [tabs])
 
   const entries = useMemo<HubEntry[]>(() =>
@@ -100,31 +98,18 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
     pinned: entries.filter(e => e.pane.pinned).length,
   }), [entries])
 
-  const filterIs = (f: HubFilter) =>
-    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
-
   return (
     <div className="hub-view">
       <div className="hub-toolbar">
-        <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
+        <button className={`hub-chip${filter === 'all' ? ' on' : ''}`} onClick={() => changeFilter('all')}>
           Todas <span className="hub-chip-n">{counts.all}</span>
         </button>
-        <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
+        <button className={`hub-chip${filter === 'active' ? ' on' : ''}`} onClick={() => changeFilter('active')}>
           Activas <span className="hub-chip-n">{counts.active}</span>
         </button>
-        <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
+        <button className={`hub-chip${filter === 'pinned' ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
           Pineadas <span className="hub-chip-n">{counts.pinned}</span>
         </button>
-        <span className="hub-toolbar-sep" />
-        {sourceTabs.map(t => (
-          <button
-            key={t.id}
-            className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
-            onClick={() => changeFilter({ tabId: t.id })}
-          >
-            {t.name}
-          </button>
-        ))}
         {pageCount > 1 && (
           <span className="hub-pager">
             <button className="hub-chip hub-pager-btn" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))} aria-label="Página anterior">

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { WorkspaceTab } from '../types'
+import HubGrid, { HubEntry, HubFilter, filterEntries } from './HubGrid'
+
+const PAGE_SIZE = 12
+const FILTER_STORAGE_KEY = 'nest-hub-filter'
+
+function loadFilter(): HubFilter {
+  const raw = localStorage.getItem(FILTER_STORAGE_KEY)
+  if (raw === 'active' || raw === 'pinned') return raw
+  if (raw?.startsWith('tab:')) return { tabId: raw.slice(4) }
+  return 'all'
+}
+function saveFilter(f: HubFilter) {
+  localStorage.setItem(FILTER_STORAGE_KEY, typeof f === 'string' ? f : `tab:${f.tabId}`)
+}
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  activePanes: Set<string>
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogglePin }: Props) {
+  const [filter, setFilter] = useState<HubFilter>(loadFilter)
+  const [page, setPage] = useState(0)
+  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(null)
+
+  // Hub tabs own no terminals; exclude them so they don't appear as empty
+  // per-workspace filter chips or contribute phantom entries.
+  const sourceTabs = useMemo(() => tabs.filter(t => !t.isHub), [tabs])
+
+  const entries = useMemo<HubEntry[]>(() =>
+    sourceTabs.flatMap(t =>
+      t.panes
+        .filter(p => p.aiType !== 'browser')
+        .map(p => ({
+          pane: p,
+          tabId: t.id,
+          tabName: t.name,
+          isActiveTab: t.id === activeTabId,
+          busy: activePanes.has(p.id),
+        }))
+    ), [sourceTabs, activeTabId, activePanes])
+
+  const filtered = useMemo(() => filterEntries(entries, filter), [entries, filter])
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const visible = filtered.slice(clampedPage * PAGE_SIZE, (clampedPage + 1) * PAGE_SIZE)
+
+  const changeFilter = useCallback((f: HubFilter) => {
+    setFilter(f); setPage(0); saveFilter(f)
+  }, [])
+
+  useEffect(() => {
+    if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
+      setFocusedPaneId(null)
+    }
+  }, [visible, focusedPaneId])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+        if (visible.length === 0) return
+        const idx = visible.findIndex(en => en.pane.id === focusedPaneId)
+        const next = e.shiftKey
+          ? (idx - 1 + visible.length) % visible.length
+          : (idx + 1) % visible.length
+        setFocusedPaneId(visible[next].pane.id)
+        return
+      }
+      if (e.key === 'Enter' && focusedPaneId) {
+        const entry = visible.find(en => en.pane.id === focusedPaneId)
+        if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
+          e.preventDefault()
+          onJump(entry.tabId, entry.pane.id)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler, true)
+    return () => window.removeEventListener('keydown', handler, true)
+  }, [visible, focusedPaneId, onJump])
+
+  const counts = useMemo(() => ({
+    all: entries.length,
+    active: entries.filter(e => e.busy).length,
+    pinned: entries.filter(e => e.pane.pinned).length,
+  }), [entries])
+
+  const filterIs = (f: HubFilter) =>
+    typeof f === 'string' ? filter === f : typeof filter !== 'string' && filter.tabId === f.tabId
+
+  return (
+    <div className="hub-view">
+      <div className="hub-toolbar">
+        <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => changeFilter('all')}>
+          Todas <span className="hub-chip-n">{counts.all}</span>
+        </button>
+        <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => changeFilter('active')}>
+          Activas <span className="hub-chip-n">{counts.active}</span>
+        </button>
+        <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => changeFilter('pinned')}>
+          Pineadas <span className="hub-chip-n">{counts.pinned}</span>
+        </button>
+        <span className="hub-toolbar-sep" />
+        {sourceTabs.map(t => (
+          <button
+            key={t.id}
+            className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
+            onClick={() => changeFilter({ tabId: t.id })}
+          >
+            {t.name}
+          </button>
+        ))}
+        {pageCount > 1 && (
+          <span className="hub-pager">
+            <button className="hub-chip" disabled={clampedPage === 0} onClick={() => setPage(p => Math.max(0, p - 1))}>‹</button>
+            <span className="hub-pager-label">{clampedPage + 1}/{pageCount}</span>
+            <button className="hub-chip" disabled={clampedPage >= pageCount - 1} onClick={() => setPage(p => p + 1)}>›</button>
+          </span>
+        )}
+      </div>
+      <HubGrid
+        entries={visible}
+        focusedPaneId={focusedPaneId}
+        onFocus={setFocusedPaneId}
+        onJump={onJump}
+        onTogglePin={onTogglePin}
+      />
+    </div>
+  )
+}

--- a/src/components/HubView.tsx
+++ b/src/components/HubView.tsx
@@ -54,12 +54,17 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
     setFilter(f); setPage(0); saveFilter(f)
   }, [])
 
+  // If the focused pane left the visible set (filter change, pane closed),
+  // drop focus so Tab cycling restarts from the first tile.
   useEffect(() => {
     if (focusedPaneId && !visible.some(e => e.pane.id === focusedPaneId)) {
       setFocusedPaneId(null)
     }
   }, [visible, focusedPaneId])
 
+  // Keyboard: Tab cycles tiles; Enter jumps to the focused pane's workspace.
+  // In the overlay, Escape is handled centrally in App.tsx (capture phase) so
+  // its priority lives in one place; the workspace variant has no Escape.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
@@ -74,6 +79,8 @@ export default function HubView({ tabs, activeTabId, activePanes, onJump, onTogg
       }
       if (e.key === 'Enter' && focusedPaneId) {
         const entry = visible.find(en => en.pane.id === focusedPaneId)
+        // Only when the xterm itself isn't consuming Enter (i.e. the tile is
+        // focused via Tab but the user hasn't clicked into the terminal).
         if (entry && !(document.activeElement?.closest('.hub-tile-terminal'))) {
           e.preventDefault()
           onJump(entry.tabId, entry.pane.id)

--- a/src/components/HubWorkspace.tsx
+++ b/src/components/HubWorkspace.tsx
@@ -1,0 +1,18 @@
+import { WorkspaceTab } from '../types'
+import HubView from './HubView'
+
+interface Props {
+  tabs: WorkspaceTab[]
+  activeTabId: string
+  activePanes: Set<string>
+  onJump: (tabId: string, paneId: string) => void
+  onTogglePin: (tabId: string, paneId: string) => void
+}
+
+export default function HubWorkspace(props: Props) {
+  return (
+    <div className="hub-workspace">
+      <HubView {...props} />
+    </div>
+  )
+}

--- a/src/components/HubWorkspace.tsx
+++ b/src/components/HubWorkspace.tsx
@@ -13,7 +13,6 @@ interface Props {
   panes: PaneNode[]                          // ya filtrados + ordenados (máx. 12)
   layoutId: LayoutId
   splitRatios?: Record<string, number[]>
-  sourceTabs: { id: string; name: string }[]
   filter: HubFilter
   counts: { all: number; active: number; pinned: number }
   hiddenCount: number
@@ -28,36 +27,25 @@ interface Props {
 
 // El Hub como workspace: mismas terminales de todos los workspaces, renderizadas
 // con el motor de layout normal (1 = pantalla completa, N = tileadas, resize y
-// reorder), con una barra de filtros delgada arriba.
+// reorder), con una barra de filtros delgada arriba. Los filtros son solo
+// transversales (Todas / Activas / Pineadas): filtrar por-workspace sería lo
+// mismo que ir a esa pestaña, así que no existe.
 export default function HubWorkspace({
-  panes, layoutId, splitRatios, sourceTabs, filter, counts, hiddenCount,
+  panes, layoutId, splitRatios, filter, counts, hiddenCount,
   onFilter, onResize, onDragStart, onDragEnd, draggingId, sensors, renderPane,
 }: Props) {
-  const filterIs = (f: HubFilter) =>
-    typeof f === 'string' ? filter === f : (typeof filter !== 'string' && filter.tabId === f.tabId)
-
   return (
     <div className="hub-workspace">
       <div className="hub-toolbar">
-        <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => onFilter('all')}>
+        <button className={`hub-chip${filter === 'all' ? ' on' : ''}`} onClick={() => onFilter('all')}>
           Todas <span className="hub-chip-n">{counts.all}</span>
         </button>
-        <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => onFilter('active')}>
+        <button className={`hub-chip${filter === 'active' ? ' on' : ''}`} onClick={() => onFilter('active')}>
           Activas <span className="hub-chip-n">{counts.active}</span>
         </button>
-        <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => onFilter('pinned')}>
+        <button className={`hub-chip${filter === 'pinned' ? ' on' : ''}`} onClick={() => onFilter('pinned')}>
           Pineadas <span className="hub-chip-n">{counts.pinned}</span>
         </button>
-        <span className="hub-toolbar-sep" />
-        {sourceTabs.map(t => (
-          <button
-            key={t.id}
-            className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
-            onClick={() => onFilter({ tabId: t.id })}
-          >
-            {t.name}
-          </button>
-        ))}
         {hiddenCount > 0 && <span className="hub-hidden-note">+{hiddenCount} sin mostrar (máx. 12)</span>}
       </div>
 

--- a/src/components/HubWorkspace.tsx
+++ b/src/components/HubWorkspace.tsx
@@ -1,18 +1,90 @@
-import { WorkspaceTab } from '../types'
-import HubView from './HubView'
+import type { ReactNode } from 'react'
+import {
+  DndContext, DragOverlay, closestCenter,
+  type DragStartEvent, type DragEndEvent,
+  type SensorDescriptor, type SensorOptions,
+} from '@dnd-kit/core'
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable'
+import { PaneLayoutEngine } from './PaneLayoutEngine'
+import type { PaneNode, LayoutId } from '../types'
+import type { HubFilter } from './HubGrid'
 
 interface Props {
-  tabs: WorkspaceTab[]
-  activeTabId: string
-  activePanes: Set<string>
-  onJump: (tabId: string, paneId: string) => void
-  onTogglePin: (tabId: string, paneId: string) => void
+  panes: PaneNode[]                          // ya filtrados + ordenados (máx. 12)
+  layoutId: LayoutId
+  splitRatios?: Record<string, number[]>
+  sourceTabs: { id: string; name: string }[]
+  filter: HubFilter
+  counts: { all: number; active: number; pinned: number }
+  hiddenCount: number
+  onFilter: (f: HubFilter) => void
+  onResize: (path: string, sizes: number[]) => void
+  onDragStart: (e: DragStartEvent) => void
+  onDragEnd: (e: DragEndEvent) => void
+  draggingId: string | null
+  sensors: SensorDescriptor<SensorOptions>[]
+  renderPane: (pane: PaneNode) => ReactNode
 }
 
-export default function HubWorkspace(props: Props) {
+// El Hub como workspace: mismas terminales de todos los workspaces, renderizadas
+// con el motor de layout normal (1 = pantalla completa, N = tileadas, resize y
+// reorder), con una barra de filtros delgada arriba.
+export default function HubWorkspace({
+  panes, layoutId, splitRatios, sourceTabs, filter, counts, hiddenCount,
+  onFilter, onResize, onDragStart, onDragEnd, draggingId, sensors, renderPane,
+}: Props) {
+  const filterIs = (f: HubFilter) =>
+    typeof f === 'string' ? filter === f : (typeof filter !== 'string' && filter.tabId === f.tabId)
+
   return (
     <div className="hub-workspace">
-      <HubView {...props} />
+      <div className="hub-toolbar">
+        <button className={`hub-chip${filterIs('all') ? ' on' : ''}`} onClick={() => onFilter('all')}>
+          Todas <span className="hub-chip-n">{counts.all}</span>
+        </button>
+        <button className={`hub-chip${filterIs('active') ? ' on' : ''}`} onClick={() => onFilter('active')}>
+          Activas <span className="hub-chip-n">{counts.active}</span>
+        </button>
+        <button className={`hub-chip${filterIs('pinned') ? ' on' : ''}`} onClick={() => onFilter('pinned')}>
+          Pineadas <span className="hub-chip-n">{counts.pinned}</span>
+        </button>
+        <span className="hub-toolbar-sep" />
+        {sourceTabs.map(t => (
+          <button
+            key={t.id}
+            className={`hub-chip${filterIs({ tabId: t.id }) ? ' on' : ''}`}
+            onClick={() => onFilter({ tabId: t.id })}
+          >
+            {t.name}
+          </button>
+        ))}
+        {hiddenCount > 0 && <span className="hub-hidden-note">+{hiddenCount} sin mostrar (máx. 12)</span>}
+      </div>
+
+      {panes.length === 0 ? (
+        <div className="hub-empty">No hay terminales para este filtro</div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+        >
+          <SortableContext items={panes.map(p => p.id)} strategy={rectSortingStrategy}>
+            <PaneLayoutEngine
+              layoutId={layoutId}
+              panes={panes}
+              splitRatios={splitRatios}
+              onResize={onResize}
+              renderPane={renderPane}
+              renderEmpty={() => <div className="hub-empty-slot" />}
+            />
+          </SortableContext>
+          <DragOverlay>
+            {draggingId ? <div className="drag-overlay-pane hub-drag-overlay" /> : null}
+          </DragOverlay>
+        </DndContext>
+      )}
     </div>
   )
 }

--- a/src/components/PaneHeader.tsx
+++ b/src/components/PaneHeader.tsx
@@ -39,7 +39,7 @@ interface Props {
   repoPathDiverged?: boolean
   onSyncCwd?: () => void
   ports?: number[]
-  onTogglePin?: () => void  // solo se pasa desde el Hub → muestra el botón de pin
+  onTogglePin?: () => void  // muestra el botón de pin (marca el pane para el filtro Pineadas del Hub)
 }
 
 export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChange, onNoteChange, dragHandleProps, processEnded, isBusy, onRestart, onSaveConversation, onCopyLastResponse, showBlocks, blockCount, onToggleBlocks, onShare, isSharing, repoPathDiverged, onSyncCwd, ports = [], onTogglePin }: Props) {

--- a/src/components/PaneHeader.tsx
+++ b/src/components/PaneHeader.tsx
@@ -39,9 +39,10 @@ interface Props {
   repoPathDiverged?: boolean
   onSyncCwd?: () => void
   ports?: number[]
+  onTogglePin?: () => void  // solo se pasa desde el Hub → muestra el botón de pin
 }
 
-export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChange, onNoteChange, dragHandleProps, processEnded, isBusy, onRestart, onSaveConversation, onCopyLastResponse, showBlocks, blockCount, onToggleBlocks, onShare, isSharing, repoPathDiverged, onSyncCwd, ports = [] }: Props) {
+export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChange, onNoteChange, dragHandleProps, processEnded, isBusy, onRestart, onSaveConversation, onCopyLastResponse, showBlocks, blockCount, onToggleBlocks, onShare, isSharing, repoPathDiverged, onSyncCwd, ports = [], onTogglePin }: Props) {
   const config = AI_CONFIG[pane.aiType]
   const displayLabel = pane.customLabel ?? config.label
   const displayColor = pane.customColor ?? config.color
@@ -221,6 +222,24 @@ export default function PaneHeader({ pane, zoomed, onZoom, onClose, onColorChang
             <path d="M10 1v3H7" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
           Restart
+        </button>
+      )}
+
+      {onTogglePin && (
+        <button
+          className={`pane-pin-btn${pane.pinned ? ' pinned' : ''}`}
+          onClick={onTogglePin}
+          title={pane.pinned ? 'Quitar pin del Hub' : 'Pinear en el Hub'}
+        >
+          {pane.pinned ? (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M9 4v6l-2 3v2h10v-2l-2-3V4z" /><rect x="11" y="17" width="2" height="4" />
+            </svg>
+          ) : (
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M9 4v6l-2 3v2h10v-2l-2-3V4z" /><path d="M12 17v4" />
+            </svg>
+          )}
         </button>
       )}
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -102,7 +102,14 @@ const SortableTab = memo(function SortableTab({
           {...attributes}
           style={{ cursor: 'grab' }}
         >
-          {tab.isHub && <span className="tab-hub-icon">▦</span>}
+          {tab.isHub && (
+            <span className="tab-hub-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+                <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" />
+                <rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+            </span>
+          )}
           {tab.name}
           {tab.repoPath && basename(tab.repoPath) !== tab.name && (
             <span className="tab-repo-badge" title={tab.repoPath}>{basename(tab.repoPath)}</span>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -102,6 +102,7 @@ const SortableTab = memo(function SortableTab({
           {...attributes}
           style={{ cursor: 'grab' }}
         >
+          {tab.isHub && <span className="tab-hub-icon">▦</span>}
           {tab.name}
           {tab.repoPath && basename(tab.repoPath) !== tab.name && (
             <span className="tab-repo-badge" title={tab.repoPath}>{basename(tab.repoPath)}</span>

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -60,9 +60,10 @@ interface Props {
   style?: React.CSSProperties
   allowSharing?: boolean
   onRequireUpgrade?: () => void
+  onTogglePin?: () => void  // solo desde el Hub → habilita el botón de pin en el header
 }
 
-export default function TerminalPane({ pane, isDragging, zoomed, zoomingOut, onZoom, onClose, onColorChange, onNoteChange, onInput, onBusyChange, onFocus, onActivity, onJoinRequest, onPtyStarted, ports = [], fontSize, style, allowSharing = true, onRequireUpgrade }: Props) {
+export default function TerminalPane({ pane, isDragging, zoomed, zoomingOut, onZoom, onClose, onColorChange, onNoteChange, onInput, onBusyChange, onFocus, onActivity, onJoinRequest, onPtyStarted, ports = [], fontSize, style, allowSharing = true, onRequireUpgrade, onTogglePin }: Props) {
   const cmdBufferRef = useRef('')
   const wrappedOnInput = useCallback((data: string) => {
     for (const ch of data) {
@@ -428,6 +429,7 @@ export default function TerminalPane({ pane, isDragging, zoomed, zoomingOut, onZ
         isSharing={isSharing}
         repoPathDiverged={repoPathDiverged}
         onSyncCwd={handleSyncCwd}
+        onTogglePin={onTogglePin}
       />
       {searchOpen && (
         <div className="search-bar">

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -60,7 +60,7 @@ interface Props {
   style?: React.CSSProperties
   allowSharing?: boolean
   onRequireUpgrade?: () => void
-  onTogglePin?: () => void  // solo desde el Hub → habilita el botón de pin en el header
+  onTogglePin?: () => void  // habilita el botón de pin en el header (marca el pane para el Hub)
 }
 
 export default function TerminalPane({ pane, isDragging, zoomed, zoomingOut, onZoom, onClose, onColorChange, onNoteChange, onInput, onBusyChange, onFocus, onActivity, onJoinRequest, onPtyStarted, ports = [], fontSize, style, allowSharing = true, onRequireUpgrade, onTogglePin }: Props) {

--- a/src/hooks/useHubTerminal.ts
+++ b/src/hooks/useHubTerminal.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { subscribeToPtyData } from '../pty-events'
+
+// Replay only the tail of the 10k-line main-process buffer — a compact tile
+// doesn't need full scroll-back and writing 10k lines × 12 tiles at once
+// would jank the overlay open animation.
+const TAIL_LINES = 200
+
+/**
+ * Lightweight xterm for Hub tiles. Attaches to an EXISTING PTY by paneId:
+ * replays the buffer tail, subscribes to the global data bus, forwards input.
+ * Never creates or kills the PTY, never touches the pane registries
+ * (registerPane/registerTerminal are single-slot per paneId and belong to
+ * the real TerminalPane).
+ *
+ * PTY resize policy: only when `canResizePty` (pane is NOT in the active
+ * tab — active-tab panes stay mounted at real size behind the overlay) and
+ * only when this tile owns keyboard focus.
+ */
+export function useHubTerminal(paneId: string, canResizePty: boolean) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
+  const canResizeRef = useRef(canResizePty)
+  canResizeRef.current = canResizePty
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const fontFamily = window.platform?.isMac
+      ? '"SF Mono", "Menlo", "Monaco", monospace'
+      : '"Cascadia Mono", "Cascadia Code", "Consolas", monospace'
+
+    const term = new Terminal({
+      fontFamily,
+      fontSize: 11,
+      lineHeight: 1.3,
+      cursorBlink: false,
+      cursorStyle: 'bar',
+      scrollback: 1000,
+      theme: {
+        background: '#000000',
+        foreground: '#e8e8e8',
+        cursor: '#0066FF',
+        selectionBackground: '#0066FF33',
+      },
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(container)
+    termRef.current = term
+    fitRef.current = fit
+
+    // Fit the xterm view to the tile WITHOUT resizing the PTY — view-only.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        try { fit.fit() } catch { /* ignore */ }
+      })
+    })
+
+    let alive = true
+    window.pty.getBuffer(paneId).then((buf) => {
+      if (!alive || !buf) return
+      const tail = buf.split('\n').slice(-TAIL_LINES).join('\n')
+      term.write(tail)
+    })
+
+    const unsubscribe = subscribeToPtyData((id, data) => {
+      if (id === paneId) term.write(data)
+    })
+
+    // Input flows only when this xterm has DOM focus — xterm only emits
+    // onData for the focused instance, so no extra gating is needed.
+    term.onData((data) => window.pty.write(paneId, data))
+
+    const resizeObserver = new ResizeObserver(() => {
+      requestAnimationFrame(() => {
+        try {
+          if (!container.clientWidth || !container.clientHeight) return
+          fit.fit()
+          if (canResizeRef.current && container.contains(document.activeElement)) {
+            window.pty.resize(paneId, term.cols, term.rows)
+          }
+        } catch { /* ignore */ }
+      })
+    })
+    resizeObserver.observe(container)
+
+    return () => {
+      alive = false
+      unsubscribe()
+      resizeObserver.disconnect()
+      // Do NOT kill the PTY — same contract as TerminalPane.
+      term.dispose()
+    }
+  }, [paneId])
+
+  const focusTile = useCallback(() => {
+    const term = termRef.current
+    if (!term) return
+    term.focus()
+    if (canResizeRef.current && fitRef.current) {
+      try {
+        fitRef.current.fit()
+        window.pty.resize(paneId, term.cols, term.rows)
+      } catch { /* ignore */ }
+    }
+  }, [paneId])
+
+  return { containerRef, focusTile }
+}

--- a/src/hub-activity.ts
+++ b/src/hub-activity.ts
@@ -1,0 +1,54 @@
+// Always-on cross-workspace activity signal for the Hub. Unlike busyPanes
+// (driven only by the mounted active-tab TerminalPanes), this listens to the
+// global PTY data bus, so it reflects background workspaces too. A pane is
+// "active" while it has emitted output within ACTIVE_QUIET_MS.
+import { useSyncExternalStore } from 'react'
+import { subscribeToPtyData } from './pty-events'
+
+const ACTIVE_QUIET_MS = 2000
+
+const active = new Set<string>()
+const timers = new Map<string, ReturnType<typeof setTimeout>>()
+const listeners = new Set<() => void>()
+let snapshot: Set<string> = new Set()
+let started = false
+
+function publish() {
+  snapshot = new Set(active)
+  for (const l of listeners) l()
+}
+
+function ensureStarted() {
+  if (started) return
+  started = true
+  subscribeToPtyData((paneId) => {
+    const isNew = !active.has(paneId)
+    active.add(paneId)
+    const prev = timers.get(paneId)
+    if (prev) clearTimeout(prev)
+    timers.set(paneId, setTimeout(() => {
+      active.delete(paneId)
+      timers.delete(paneId)
+      publish()
+    }, ACTIVE_QUIET_MS))
+    // Publish only on membership transitions (idle→active); the per-byte
+    // timer reset above keeps an already-active pane active without churning
+    // subscribers on every chunk.
+    if (isNew) publish()
+  })
+}
+
+function subscribe(cb: () => void): () => void {
+  ensureStarted()
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}
+
+function getSnapshot(): Set<string> {
+  return snapshot
+}
+
+/** Set of paneIds that emitted output within the last ACTIVE_QUIET_MS. */
+export function useHubActivity(): Set<string> {
+  return useSyncExternalStore(subscribe, getSnapshot)
+}

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -3,6 +3,7 @@ export interface Keybindings {
   newPane: string
   globalSearch: string
   commandPalette: string
+  hubOverlay: string
   nextPane: string
   prevPane: string
   nextTab: string
@@ -25,6 +26,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     newPane: 'Meta+t',
     globalSearch: 'Meta+f',
     commandPalette: 'Meta+k',
+    hubOverlay: 'Meta+Shift+O',
     nextPane: 'Meta+ArrowRight',
     prevPane: 'Meta+ArrowLeft',
     nextTab: 'Ctrl+Tab',

--- a/src/pty-events.ts
+++ b/src/pty-events.ts
@@ -3,10 +3,12 @@
 type DataCallback = (data: string) => void
 type ExitCallback = () => void
 type GlobalDataCallback = (paneId: string, data: string) => void
+type GlobalExitCallback = (paneId: string) => void
 
 const dataCallbacks = new Map<string, DataCallback>()
 const exitCallbacks = new Map<string, ExitCallback>()
 const globalDataSubscribers = new Set<GlobalDataCallback>()
+const globalExitSubscribers = new Set<GlobalExitCallback>()
 
 let ipcRegistered = false
 
@@ -17,7 +19,10 @@ function ensureIpcRegistered() {
     dataCallbacks.get(paneId)?.(data)
     for (const cb of globalDataSubscribers) cb(paneId, data)
   })
-  window.pty.onExit((paneId) => exitCallbacks.get(paneId)?.())
+  window.pty.onExit((paneId) => {
+    exitCallbacks.get(paneId)?.()
+    for (const cb of globalExitSubscribers) cb(paneId)
+  })
 }
 
 export function registerPane(paneId: string, onData: DataCallback, onExit?: ExitCallback) {
@@ -38,6 +43,13 @@ export function subscribeToPtyData(cb: GlobalDataCallback): () => void {
   return () => { globalDataSubscribers.delete(cb) }
 }
 
+/** Subscribe to exit events from all panes. Returns an unsubscribe function. */
+export function subscribeToPtyExit(cb: GlobalExitCallback): () => void {
+  ensureIpcRegistered()
+  globalExitSubscribers.add(cb)
+  return () => { globalExitSubscribers.delete(cb) }
+}
+
 /**
  * Tear down the global IPC listeners and clear subscriber maps. Intended to
  * run on window `beforeunload` so the renderer doesn't leak listeners (or
@@ -48,6 +60,7 @@ export function stopListening(): void {
   dataCallbacks.clear()
   exitCallbacks.clear()
   globalDataSubscribers.clear()
+  globalExitSubscribers.clear()
   ipcRegistered = false
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9406,9 +9406,9 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .hub-chip.on {
-  color: var(--raven-blue);
-  background: #0066FF15;
-  border-color: #0066FF30;
+  color: var(--text-primary);
+  background: #161616;
+  border-color: #2a2a2a;
 }
 
 .hub-chip:disabled {
@@ -9442,15 +9442,30 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .hub-pager-label {
   font-size: 10px;
   color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.hub-pager-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 5px;
+}
+
+.hub-pager-btn svg {
+  width: 11px;
+  height: 11px;
 }
 
 .hub-grid {
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  grid-auto-rows: minmax(180px, 1fr);
-  gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 380px));
+  grid-auto-rows: 210px;
+  align-content: start;
+  justify-content: start;
+  gap: 8px;
   padding: 8px;
   overflow-y: auto;
 }
@@ -9465,20 +9480,31 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .hub-tile {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
   background: var(--bg-app);
-  border: 1.5px solid color-mix(in srgb, var(--pane-color, var(--border)) 40%, transparent);
+  border: 1px solid var(--border);
   border-radius: 4px;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 12%, transparent);
+}
+
+/* Única marca de color del tile: franja fina con el color del agente/pane. */
+.hub-tile::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--pane-color, transparent);
+  z-index: 1;
 }
 
 .hub-tile.focused {
-  border-color: color-mix(in srgb, var(--pane-color, var(--raven-blue)) 85%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 25%, transparent),
-              0 0 12px -2px color-mix(in srgb, var(--pane-color, transparent) 45%, transparent);
+  border-color: #565656;
+  box-shadow: 0 0 0 1px #565656;
 }
 
 .hub-tile-header {
@@ -9488,7 +9514,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
   align-items: center;
   gap: 7px;
   padding: 0 8px;
-  background: color-mix(in srgb, var(--pane-color, var(--bg-surface)) 8%, var(--bg-surface));
+  background: var(--bg-surface);
   font-size: 10px;
   user-select: none;
 }
@@ -9506,9 +9532,9 @@ body.platform-mac .tabbar { padding-right: 116px; }
   font-weight: 600;
   font-family: 'SF Mono', 'Menlo', monospace;
   letter-spacing: 0.4px;
-  color: var(--raven-blue);
-  background: #0066FF15;
-  border: 1px solid #0066FF30;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
   border-radius: 3px;
   padding: 1px 5px;
   flex-shrink: 0;
@@ -9532,17 +9558,21 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .hub-tile-pin {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.4px;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-muted);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 3px;
-  padding: 1px 5px;
+  border-radius: 4px;
+  padding: 2px;
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.hub-tile-pin svg {
+  width: 12px;
+  height: 12px;
 }
 
 .hub-tile-pin:hover {
@@ -9551,9 +9581,7 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .hub-tile-pin.pinned {
-  color: var(--raven-blue);
-  border-color: #0066FF30;
-  background: #0066FF15;
+  color: var(--text-primary);
 }
 
 .hub-tile-terminal {
@@ -9563,28 +9591,8 @@ body.platform-mac .tabbar { padding-right: 116px; }
   overflow: hidden;
 }
 
-/* Botón Hub en la tab bar (va dentro del rightSlot, zona no-drag) */
-.hub-btn {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-  padding: 3px 8px;
-  cursor: pointer;
-  -webkit-app-region: no-drag;
-  transition: color 0.15s, border-color 0.15s;
-  position: relative;
-}
-
-.hub-btn:hover {
-  color: var(--raven-blue);
-  border-color: #0066FF44;
-}
+/* El Hub ya no tiene botón en la tab bar: se entra desde el estado vacío
+   (como workspace) o con el atajo Ctrl/Cmd+Shift+O (overlay). */
 
 .hub-view {
   flex: 1;
@@ -9601,27 +9609,75 @@ body.platform-mac .tabbar { padding-right: 116px; }
 }
 
 .tab-hub-icon {
-  color: var(--raven-blue);
-  margin-right: 5px;
-  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  margin-right: 6px;
+}
+
+.tab-hub-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Entrada al Hub desde el estado vacío: camino secundario, discreto,
+   separado por una hairline "o". */
+.empty-or {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 236px;
+  margin: 26px 0 2px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.empty-or::before,
+.empty-or::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: var(--border);
 }
 
 .empty-hub-btn {
-  margin-top: 14px;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   background: transparent;
-  border: 1px solid var(--raven-blue);
-  color: var(--raven-blue);
-  border-radius: 6px;
-  padding: 8px 16px;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  border-radius: 7px;
+  padding: 9px 16px;
   font-size: 13px;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: color 0.15s, border-color 0.15s;
 }
 
 .empty-hub-btn:hover {
-  background: #0066FF18;
+  color: var(--text-primary);
+  border-color: #333;
+}
+
+.empty-hub-btn svg {
+  width: 15px;
+  height: 15px;
+  color: var(--text-muted);
+}
+
+.empty-hub-btn:hover svg {
+  color: var(--text-secondary);
+}
+
+.empty-hub-count {
+  font-family: 'SF Mono', 'Menlo', monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  border-left: 1px solid var(--border);
+  padding-left: 9px;
+  margin-left: 2px;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9329,3 +9329,259 @@ body.platform-mac .tabbar { padding-right: 116px; }
 .tour-progress i.on { background: #3d79ff; width: 14px; border-radius: 3px; }
 .tour-help-btn { background: none; border: 1px solid #2b2b32; color: #9a9aa3; border-radius: 8px; width: 26px; height: 26px; cursor: pointer; font-size: 14px; }
 .tour-help-btn:hover { color: #ededed; border-color: #3a3a42; }
+
+/* ── Hub Overlay ─────────────────────────────────────────── */
+
+.hub-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+}
+
+.hub-panel {
+  width: 100%;
+  height: 100%;
+  max-width: 1400px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.75);
+  overflow: hidden;
+}
+
+.hub-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  user-select: none;
+}
+
+.hub-title-hint {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.hub-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  user-select: none;
+}
+
+.hub-chip {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.hub-chip:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.hub-chip.on {
+  color: var(--raven-blue);
+  background: #0066FF15;
+  border-color: #0066FF30;
+}
+
+.hub-chip:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.hub-chip-n {
+  color: var(--text-muted);
+  margin-left: 3px;
+}
+
+.hub-chip.on .hub-chip-n {
+  color: var(--text-secondary);
+}
+
+.hub-toolbar-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--border);
+  margin: 0 3px;
+}
+
+.hub-pager {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hub-pager-label {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.hub-grid {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-auto-rows: minmax(180px, 1fr);
+  gap: 6px;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.hub-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hub-tile {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-app);
+  border: 1.5px solid color-mix(in srgb, var(--pane-color, var(--border)) 40%, transparent);
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 12%, transparent);
+}
+
+.hub-tile.focused {
+  border-color: color-mix(in srgb, var(--pane-color, var(--raven-blue)) 85%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--pane-color, transparent) 25%, transparent),
+              0 0 12px -2px color-mix(in srgb, var(--pane-color, transparent) 45%, transparent);
+}
+
+.hub-tile-header {
+  height: 26px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 8px;
+  background: color-mix(in srgb, var(--pane-color, var(--bg-surface)) 8%, var(--bg-surface));
+  font-size: 10px;
+  user-select: none;
+}
+
+.hub-tile-header .pane-ai-label {
+  font-size: 10px;
+}
+
+.hub-tile-header .pane-account-name {
+  font-size: 10px;
+}
+
+.hub-tile-ws {
+  font-size: 9px;
+  font-weight: 600;
+  font-family: 'SF Mono', 'Menlo', monospace;
+  letter-spacing: 0.4px;
+  color: var(--raven-blue);
+  background: #0066FF15;
+  border: 1px solid #0066FF30;
+  border-radius: 3px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+  max-width: 110px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-tile-busy {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22C55E;
+  flex-shrink: 0;
+  animation: activityPulse 1.5s ease-in-out infinite;
+}
+
+.hub-tile-spacer {
+  flex: 1;
+}
+
+.hub-tile-pin {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  padding: 1px 5px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.hub-tile-pin:hover {
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.hub-tile-pin.pinned {
+  color: var(--raven-blue);
+  border-color: #0066FF30;
+  background: #0066FF15;
+}
+
+.hub-tile-terminal {
+  flex: 1;
+  min-height: 0;
+  padding: 4px 6px;
+  overflow: hidden;
+}
+
+/* Botón Hub en la tab bar (va dentro del rightSlot, zona no-drag) */
+.hub-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  transition: color 0.15s, border-color 0.15s;
+  position: relative;
+}
+
+.hub-btn:hover {
+  color: var(--raven-blue);
+  border-color: #0066FF44;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9450,13 +9450,6 @@ body.platform-mac .tabbar { padding-right: 116px; }
   color: var(--text-secondary);
 }
 
-.hub-toolbar-sep {
-  width: 1px;
-  height: 14px;
-  background: var(--border);
-  margin: 0 3px;
-}
-
 .hub-pager {
   margin-left: auto;
   display: flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9608,6 +9608,33 @@ body.platform-mac .tabbar { padding-right: 116px; }
   flex-direction: column;
 }
 
+/* El Hub-como-workspace usa el motor de layout normal: que llene el alto. */
+.hub-workspace .grid-workspace {
+  flex: 1;
+  min-height: 0;
+}
+
+.hub-hidden-note {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.hub-empty-slot {
+  width: 100%;
+  height: 100%;
+  background: var(--bg-app);
+}
+
+.hub-drag-overlay {
+  width: 220px;
+  height: 120px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  opacity: 0.9;
+}
+
 .tab-hub-icon {
   display: inline-flex;
   align-items: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9585,3 +9585,10 @@ body.platform-mac .tabbar { padding-right: 116px; }
   color: var(--raven-blue);
   border-color: #0066FF44;
 }
+
+.hub-view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1983,6 +1983,31 @@ body {
   color: var(--raven-blue);
 }
 
+/* Pin (solo visible en el Hub): marca el pane para el filtro Pineadas. */
+.pane-pin-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+  margin-right: 2px;
+}
+
+.pane-pin-btn:hover {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+.pane-pin-btn.pinned {
+  color: var(--text-primary);
+}
+
 /* ── Drag & Drop ─────────────────────────────────────────── */
 
 .pane-header {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9592,3 +9592,36 @@ body.platform-mac .tabbar { padding-right: 116px; }
   display: flex;
   flex-direction: column;
 }
+
+.hub-workspace {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-hub-icon {
+  color: var(--raven-blue);
+  margin-right: 5px;
+  font-size: 11px;
+}
+
+.empty-hub-btn {
+  margin-top: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 1px solid var(--raven-blue);
+  color: var(--raven-blue);
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.empty-hub-btn:hover {
+  background: #0066FF18;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,7 @@ export interface WorkspaceTab {
   panes: PaneNode[]
   splitRatios?: Record<string, number[]>
   isHub?: boolean  // true = pestaña que muestra el Hub (todas las terminales), sin panes propios
+  hubOrder?: string[]  // orden de los panes en la vista Hub (ids); reordenar por drag
 }
 
 export function equalSizes(count: number): number[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,7 @@ export interface SessionData {
     layoutId?: LayoutId
     panes?: SessionPane[]
     splitRatios?: Record<string, number[]>
+    isHub?: boolean
     // v2 legacy (kept optional for migration)
     layout?: GridLayout
     cells?: (SessionPane | null)[]
@@ -265,6 +266,7 @@ export interface WorkspaceTab {
   layoutId: LayoutId
   panes: PaneNode[]
   splitRatios?: Record<string, number[]>
+  isHub?: boolean  // true = pestaña que muestra el Hub (todas las terminales), sin panes propios
 }
 
 export function equalSizes(count: number): number[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface PaneNode {
   url?: string          // browser only: initial url
   sessionPartition?: string  // browser only: persist:browser-<workspaceId>
   shellId?: string      // terminal panes only: which shell to spawn (Windows shell picker)
+  pinned?: boolean      // Hub: user-pinned pane, shows under the "Pinned" filter
 }
 
 export interface ShellInfo {
@@ -218,6 +219,7 @@ export interface SessionPane {
   repoPath?: string
   shellId?: string
   url?: string  // browser only: last navigated URL, restored on session load
+  pinned?: boolean  // Hub pin — survives session restore
 }
 
 export interface SessionData {


### PR DESCRIPTION
## Qué hace

Rediseña el **Hub** para que sea un workspace más, con el mismo motor de layout que el resto, en vez de una vista aparte con grilla propia.

### Cambios principales
- **El Hub es un workspace con layout real**: 1 terminal = pantalla completa, N = tileadas, con resize y reorder (drag) igual que cualquier workspace. Usa `PaneLayoutEngine`, no una grilla separada.
- **Se entra desde el empty state** de un workspace vacío (no un botón arriba a la derecha).
- **Pin transversal**: el botón de pin está en el header de **todos** los panes, no solo dentro del Hub → pineás desde cualquier workspace y aparece en el filtro Pineadas del Hub.
- **Editar desde el Hub**: se puede cambiar color y nombre (nota) de una terminal directamente desde el Hub.
- **Barra de filtros delgada** arriba, solo con filtros **transversales**: `Todas / Activas / Pineadas`.

### Sobre los filtros
No hay filtro por-workspace: filtrar el Hub a un solo workspace mostraría lo mismo que ir a su pestaña, así que no aporta nada. Quedan solo los tres transversales, que son los que un workspace solo no te da.

### Diseño
Sigue los tokens monocromáticos de Nest — color solo como marca de dato (el color de cada terminal), chrome neutro.

## Notas de implementación
- El Hub reusa los PTYs existentes (`pty.exists`), no re-spawnea terminales al montarse.
- El overlay rápido (Ctrl+Shift+O) sigue existiendo con su grilla compacta (`HubView`/`HubGrid`), también sin chips por-workspace.

## Verificación
- `tsc --noEmit`: OK
- `npm test`: 181 tests OK (29 archivos)
- `npm run build`: OK
- Probado a mano con Playwright: tileado, 1=fullscreen, filtros, pin desde workspace normal, color/nombre desde el Hub, overlay.

Merge lo coordina Gero (update auto a los usuarios).